### PR TITLE
Use python based integration test and various cleanup and fixes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[MASTER]
+disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,attribute-defined-outside-init,too-many-arguments
+max-line-length=120

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -208,7 +208,7 @@ class OSBuildImage(BaseTaskHandler):
         archstr = buildconfig["arches"]
         if not archstr:
             name = buildconfig["name"]
-            raise koji.BuildError("Missing arches for tag '%{name}'")
+            raise koji.BuildError(f"Missing arches for tag '%{name}'")
         return set(koji.canonArch(a) for a in archstr.split())
 
     def make_repos_for_target(self, target_info):

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -88,6 +88,7 @@ class ComposeRequest:
             self.server = server
             self.task_id = task_id
 
+    # pylint: disable=redefined-outer-name
     def __init__(self, nvr: NVR, distro: str, ireqs: List[ImageRequest], koji: Koji):
         self.nvr = nvr
         self.distribution = distro
@@ -246,6 +247,7 @@ class OSBuildImage(BaseTaskHandler):
         self.logger.debug("user repo override: %s", urls)
         return [Repository(u.strip()) for u in urls]
 
+    # pylint: disable=arguments-differ
     def handler(self, name, version, distro, image_types, target, arches, opts):
         """Main entry point for the task"""
         self.logger.debug("Building image via osbuild %s, %s, %s, %s",

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -309,8 +309,6 @@ class OSBuildImage(BaseTaskHandler):
 
 
 # Stand alone osbuild composer API client executable
-import argparse
-
 RESET = "\033[0m"
 GREEN = "\033[32m"
 BOLD = "\033[1m"
@@ -361,6 +359,8 @@ def wait_cmd(client: Client, args):
 
 
 def main():
+    import argparse  # pylint: disable=import-outside-toplevel
+
     parser = argparse.ArgumentParser(description="osbuild composer koji API client")
     parser.add_argument("--url", metavar="URL", type=str,
                         default="http://localhost:8701/",

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -1,4 +1,20 @@
 #!/usr/bin/python3
+"""Koji osbuild integration - builder plugin
+
+This koji builder plugin provides a handler for 'osbuildImage' tasks,
+which will create compose requests via osbuild composer's koji API.
+
+Included is a basic pure-python client for composers koji API based
+on the corresponding OpenAPI. Although manually crafted it follows
+its terminology closely.
+This client is used in the `OSBuildImage`, which provides the actual
+koji integration to talk to composer.
+
+This file can also be used as an executable where it acts as a stand
+alone client for composer's API.
+"""
+
+
 import configparser
 import enum
 import json
@@ -13,6 +29,10 @@ import koji
 
 from koji.tasks import BaseTaskHandler
 
+
+# The following classes are a implementation of osbuild composer's
+# koji API. It is based on the corresponding OpenAPI specification
+# version '1' and should model it closely.
 
 class Repository:
     def __init__(self, baseurl: str, gpgkey: str = None):
@@ -288,7 +308,7 @@ class OSBuildImage(BaseTaskHandler):
         }
 
 
-# #####
+# Stand alone osbuild composer API client executable
 import argparse
 
 RESET = "\033[0m"

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -374,9 +374,9 @@ def main():
     subpar.add_argument("release", metavar="RELEASE", help='The release')
     subpar.add_argument("distro", metavar="NAME", help='The distribution')
     subpar.add_argument("repo", metavar="REPO", help='The repository to use',
-                         type=str, action="append", default=[])
+                        type=str, action="append", default=[])
     subpar.add_argument("arch", metavar="ARCHITECTURE", help='Request the architecture',
-                         type=str, nargs="+")
+                        type=str, nargs="+")
     subpar.add_argument("--format", metavar="FORMAT", help='Request the image format [qcow2]',
                         action="append", type=str, default=[])
     subpar.add_argument("--koji", metavar="URL", help='The koji url',

--- a/plugins/cli/osbuild.py
+++ b/plugins/cli/osbuild.py
@@ -98,6 +98,7 @@ def handle_osbuild_image(options, session, argv):
         print("Created task: %s" % task_id)
         print("Task info: %s/taskinfo?taskID=%s" % (options.weburl, task_id))
 
+    # pylint: disable=protected-access
     if (args.wait is None and kl._running_in_bg()) or args.wait is False:
         # either running in the background or must not wait by user's
         # request. All done.

--- a/plugins/cli/osbuild.py
+++ b/plugins/cli/osbuild.py
@@ -101,7 +101,7 @@ def handle_osbuild_image(options, session, argv):
     if (args.wait is None and kl._running_in_bg()) or args.wait is False:
         # either running in the background or must not wait by user's
         # request. All done.
-        return
+        return None
 
     session.logout()
     res = kl.watch_tasks(session, [task_id], quiet=options.quiet)

--- a/plugins/cli/osbuild.py
+++ b/plugins/cli/osbuild.py
@@ -1,4 +1,10 @@
-"""osbild koji command line client integration"""
+"""Koji osbuild integration - koji client plugin
+
+This koji plugin provides a new 'osbuild-image' command for the koji
+command line tool. It uses the 'osbuildImage' XMLRPC endpoint, that
+is provided by the koji osbuild plugin for the koji hub.
+"""
+
 
 from pprint import pprint
 

--- a/plugins/hub/osbuild.py
+++ b/plugins/hub/osbuild.py
@@ -1,14 +1,12 @@
 """Koji osbuild integration for Koji Hub"""
 import sys
-
 import jsonschema
 
-import logging
 import koji
 from koji.context import context
 
 sys.path.insert(0, "/usr/share/koji-hub/")
-import kojihub
+import kojihub  # pylint: disable=import-error, wrong-import-position
 
 
 OSBUILD_IMAGE_SCHMEA = {

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -83,13 +83,8 @@ sudo ./run-builder.sh start
 greenprint "Creating Koji tag infrastructure"
 ./make-tags.sh
 
-greenprint "Creating a compose"
-koji --server=http://localhost/kojihub \
-     --user=kojiadmin \
-     --password=kojipass \
-     --authtype=password \
-     osbuild-image Fedora-Cloud 32 fedora-32 f32-candidate x86_64 \
-     --repo 'http://download.fedoraproject.org/pub/fedora/linux/releases/32/Everything/$arch/os/'
+greenprint "Running integration tests"
+python3 -m unittest discover -v test/integration/
 
 greenprint "Stopping koji builder"
 sudo ./run-builder.sh stop

--- a/test/integration/test_koji.py
+++ b/test/integration/test_koji.py
@@ -60,3 +60,13 @@ class TestIntegration(unittest.TestCase):
                         "x86_64",
                         repo=F32_REPO)
         self.check_res(res)
+
+    def test_unknown_tag_check(self):
+        """Unknown Tag check"""
+        # Check building an unknown tag fails
+        res = self.koji("Fedora-Cloud",
+                        "32",
+                        "fedora-32",
+                        "UNKNOWNTAG",
+                        "x86_64")
+        self.check_fail(res)

--- a/test/integration/test_koji.py
+++ b/test/integration/test_koji.py
@@ -1,0 +1,62 @@
+#
+# koji integration tests
+#
+
+
+import functools
+import unittest
+import subprocess
+
+
+F32_REPO = "http://download.fedoraproject.org/pub/fedora/linux/releases/32/Everything/$arch/os"
+
+
+def koji_command(*args, _input=None, _globals=None, **kwargs):
+    args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
+    if _globals:
+        args = [f'--{k}={v}' for k, v in _globals.items()] + args
+    return subprocess.run(["koji"] + args,
+                          encoding="utf-8",
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT,
+                          input=_input,
+                          check=False)
+
+
+class TestIntegration(unittest.TestCase):
+
+    def setUp(self):
+        global_args = dict(
+            server="http://localhost/kojihub",
+            user="kojiadmin",
+            password="kojipass",
+            authtype="password")
+        self.koji = functools.partial(koji_command,
+                                      "osbuild-image",
+                                      _globals=global_args)
+
+    def check_res(self, res: subprocess.CompletedProcess):
+        if res.returncode != 0:
+            msg = ("\nkoji FAILED:" +
+                   "\n args: [" + " ".join(res.args) + "]" +
+                   "\n error: " + res.stdout)
+            self.fail(msg)
+
+    def check_fail(self, res: subprocess.CompletedProcess):
+        if res.returncode == 0:
+            msg = ("\nkoji unexpectedly succeed:" +
+                   "\n args: [" + " ".join(res.args) + "]" +
+                   "\n error: " + res.stdout)
+            self.fail(msg)
+
+    def test_compose(self):
+        """Successful compose"""
+        # Simple test of a successful compose of F32
+        # Needs the f32-candidate tag be setup properly
+        res = self.koji("Fedora-Cloud",
+                        "32",
+                        "fedora-32",
+                        "f32-candidate",
+                        "x86_64",
+                        repo=F32_REPO)
+        self.check_res(res)


### PR DESCRIPTION
Move to a python based integration test suite, which is more flexible and extensible than running tests directly from `integration.sh`. Also fix various style issues and add documentation. 