### PR TITLE
Unit test skeleton for the command line interface plugin

### DIFF
--- a/test/unit/plugintest.py
+++ b/test/unit/plugintest.py
@@ -1,0 +1,46 @@
+#
+# Test Infrastructure
+#
+
+
+import imp
+import os
+import unittest
+
+
+class PluginTest(unittest.TestCase):
+    """Base class for Plugin tests
+
+    Use the PluginTest.load_plugin class decorator to automatically
+    load a plugin. If said decorator has not been specified, the
+    `plugin` property will be set to `None`.
+    """
+
+    @staticmethod
+    def load_plugin(plugin_type):
+        def decorator(klass):
+            setattr(klass, "_plugin_type", plugin_type)
+            return klass
+        return decorator
+
+    def _load_plugin(self):
+        plugin_type = getattr(self, "_plugin_type", None)
+        if not plugin_type:
+            return None
+
+        root = os.getenv("GITHUB_WORKSPACE", os.getcwd())
+        haystack = os.path.join(root, "plugins", plugin_type)
+        fp, path, desc = imp.find_module("osbuild", [haystack])
+
+        try:
+            return imp.load_module("osbuild", fp, path, desc)
+        finally:
+            fp.close()
+
+    def setUp(self):
+        """Setup plugin testing environment
+
+        Will load the specified plugin if the derived class has
+        been decorated with `Plugintest.load_plugin()`.
+        """
+        self.plugin = self._load_plugin()

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -3,26 +3,14 @@
 #
 
 
-import unittest
-import os
-import imp
+import koji
 from flexmock import flexmock
 
-import koji
+from plugintest import PluginTest
 
 
-class TestHubPlugin(unittest.TestCase):
-    def setUp(self):
-        """Loads the plugin to self.plugin"""
-        root = os.getenv("GITHUB_WORKSPACE", os.getcwd())
-
-        haystack = os.path.join(root, "plugins", "builder")
-
-        fp, path, desc = imp.find_module("osbuild", [haystack])
-        try:
-            self.plugin = imp.load_module("osbuild", fp, path, desc)
-        finally:
-            fp.close()
+@PluginTest.load_plugin("builder")
+class TestBuilderPlugin(PluginTest):
 
     def test_unknown_build_target(self):
         session = flexmock()

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,0 +1,65 @@
+#
+# koji command line interface plugin unit tests
+#
+
+
+import contextlib
+import io
+import koji
+from flexmock import flexmock
+
+from plugintest import PluginTest
+
+
+@PluginTest.load_plugin("cli")
+class TestCliPlugin(PluginTest):
+
+    def test_basic_invocation(self):
+        # check we get the right amount of arguments
+        # i.e. we are missing the architecture here
+        argv = ["name", "version", "distro", "target"]
+
+        f = io.StringIO()
+        with self.assertRaises(SystemExit) as cm, \
+             contextlib.redirect_stderr(f):
+            self.plugin.handle_osbuild_image(None, None, argv)
+            self.assertEqual(cm.exception.code, 2)
+            self.assertIn("osbuild-image", f.getvalue())
+        f.close()
+
+    def test_target_check(self):
+        # unknown build target
+        session = flexmock()
+
+        session.should_receive("getBuildTarget") \
+               .with_args("target") \
+               .and_return(None) \
+               .once()
+
+        argv = ["name", "version", "distro", "target", "arch1"]
+        with self.assertRaises(koji.GenericError):
+            self.plugin.handle_osbuild_image(None, session, argv)
+
+        # unknown destination tag
+        build_target = {
+            "build_tag": 23,
+            "build_tag_name": "target-build",
+            "dest_tag": 42,
+            "dest_tag_name": "target-dest"  # missing!
+        }
+
+        session = flexmock()
+
+        session.should_receive("getBuildTarget") \
+               .with_args("target") \
+               .and_return(build_target) \
+               .once()
+
+        session.should_receive("getTag") \
+               .with_args(build_target["dest_tag"]) \
+               .and_return(None) \
+               .once()
+
+        argv = ["name", "version", "distro", "target", "arch1"]
+        with self.assertRaises(koji.GenericError):
+            self.plugin.handle_osbuild_image(None, session, argv)

--- a/test/unit/test_hub.py
+++ b/test/unit/test_hub.py
@@ -2,27 +2,14 @@
 # koji hub plugin unit tests
 #
 
-
-import unittest
-import os
-import imp
+import koji
 from flexmock import flexmock
 
-import koji
+from plugintest import PluginTest
 
 
-class TestHubPlugin(unittest.TestCase):
-    def setUp(self):
-        """Loads the plugin to self.plugin"""
-        root = os.getenv("GITHUB_WORKSPACE", os.getcwd())
-
-        haystack = os.path.join(root, "plugins", "hub")
-
-        fp, path, desc = imp.find_module("osbuild", [haystack])
-        try:
-            self.plugin = imp.load_module("osbuild", fp, path, desc)
-        finally:
-            fp.close()
+@PluginTest.load_plugin("hub")
+class TestHubPlugin(PluginTest):
 
     @staticmethod
     def mock_koji_context(*, admin=False):


### PR DESCRIPTION
Add the skeleton to run the cli plugin unit tests. As first check ensure that exceptions are thrown for the build target checks.