### PR TITLE
Transmit user specified repos as array of strings

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    patch: no
+    project:
+      default:
+        threshold: 5%
+codecov:
+  require_ci_to_pass: no
+comment: no

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -267,9 +267,8 @@ class OSBuildImage(BaseTaskHandler):
         return [Repository(repourl + "/$arch")]
 
     def make_repos_for_user(self, repos):
-        urls = repos.split(',')
-        self.logger.debug("user repo override: %s", urls)
-        return [Repository(u.strip()) for u in urls]
+        self.logger.debug("user repo override: %s", str(repos))
+        return [Repository(r) for r in repos]
 
     # pylint: disable=arguments-differ
     def handler(self, name, version, distro, image_types, target, arches, opts):

--- a/plugins/cli/osbuild.py
+++ b/plugins/cli/osbuild.py
@@ -76,7 +76,7 @@ def handle_osbuild_image(options, session, argv):
         opts["release"] = args.release
 
     if args.repo:
-        opts["repo"] = ",".join(args.repo)
+        opts["repo"] = args.repo
 
     # Do some early checks to be able to give quick feedback
     check_target(session, target)

--- a/plugins/hub/osbuild.py
+++ b/plugins/hub/osbuild.py
@@ -39,7 +39,10 @@ OSBUILD_IMAGE_SCHEMA = {
         {
             "type": "array",
             "description": "Architectures",
-            "minItems": 1
+            "minItems": 1,
+            "items": {
+                "type": "string"
+            }
         },
         {
             "type": "object",

--- a/plugins/hub/osbuild.py
+++ b/plugins/hub/osbuild.py
@@ -52,8 +52,11 @@ OSBUILD_IMAGE_SCHEMA = {
             "additionalProperties": False,
             "properties": {
                 "repo": {
-                    "type": "string",
-                    "description": "Repositories"
+                    "type": "array",
+                    "description": "Repositories",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "release": {
                     "type": "string",

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -338,7 +338,7 @@ class TestBuilderPlugin(PluginTest):
                 ["image_type"],
                 "fedora-candidate",
                 ["x86_64"],
-                {"repo": ",".join(repos)}]
+                {"repo": repos}]
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=["x86_64"])

--- a/test/unit/test_hub.py
+++ b/test/unit/test_hub.py
@@ -42,7 +42,8 @@ class TestHubPlugin(PluginTest):
     def test_basic(self):
         context = self.mock_koji_context()
 
-        opts = {}
+        opts = {"repo": ["repo1", "repo2"],
+                "release": "1.2.3"}
         args = ["name", "version", "distro",
                 ["image_type"],
                 "target",
@@ -56,7 +57,7 @@ class TestHubPlugin(PluginTest):
         setattr(self.plugin, "context", context)
         setattr(self.plugin, "kojihub", kojihub)
 
-        self.plugin.osbuildImage(*args, opts)
+        self.plugin.osbuildImage(*args, {})
 
     def test_input_validation(self):
         context = self.mock_koji_context()


### PR DESCRIPTION
Currently we were passing the repo information as a comma separated string, which is fragile, since urls can contain commas. Just transfer them as arrays of strings.