### PR TITLE
Better task return value, throw exceptions on build failures

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -17,7 +17,6 @@ alone client for composer's API.
 
 import configparser
 import enum
-import json
 import sys
 import time
 import urllib.parse
@@ -116,12 +115,6 @@ class ComposeRequest:
                 img.as_dict() for img in self.image_requests
             ]
         }
-
-    def to_json(self, encoding=None):
-        data = json.dumps(self.as_dict())
-        if encoding:
-            data = data.encode('utf-8')
-        return data
 
 
 class ImageStatus(enum.Enum):

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -313,17 +313,18 @@ class OSBuildImage(BaseTaskHandler):
         self.logger.debug("Waiting for comose to finish")
         status = client.wait_for_compose(cid)
 
-        if not status.is_success:
-            self.logger.error("Compose failed: %s", str(status))
-            return {
-                'koji_builds': []
-            }
 
-        return {
-            'koji_builds': [bid],
-            'composer_id': cid,
-            'build': bid,
+        result = {
+            "status": status.status,
+            "composer": {
+                "server": self.composer_url,
+                "id": cid
+            },
+            "koji": {
+                "build": bid
+            }
         }
+        return result
 
 
 # Stand alone osbuild composer API client executable

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -178,7 +178,7 @@ class Client:
         res = self.http.post(url, json=cro.as_dict())
 
         if res.status_code != 201:
-            body = res.content.strip()
+            body = res.content.decode("utf-8").strip()
             msg = f"Failed to create the compose request: {body}"
             raise koji.GenericError(msg) from None
 
@@ -192,7 +192,7 @@ class Client:
         res = self.http.get(url)
 
         if res.status_code != 200:
-            body = res.content.strip()
+            body = res.content.decode("utf-8").strip()
             msg = f"Failed to get the compose status: {body}"
             raise koji.GenericError(msg) from None
 

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -226,12 +226,16 @@ class OSBuildImage(BaseTaskHandler):
         self.koji_url = cfg["koji"]["url"]
         self.client = Client(self.composer_url)
 
+        self.logger.debug("composer: %s", self.composer_url)
+        self.logger.debug("koji: %s", self.composer_url)
+
         composer = cfg["composer"]
 
         if "ssl_cert" in composer:
             data = cfg["composer"]["ssl_cert"]
             cert = self.client.parse_certs(data)
             self.client.http.cert = cert
+            self.logger.debug("ssl cert: %s", cert)
 
         if "ssl_verify" in composer:
             try:
@@ -240,6 +244,8 @@ class OSBuildImage(BaseTaskHandler):
                 val = composer["ssl_verify"]
 
             self.client.http.verify = val
+            self.logger.debug("ssl verify: %s", val)
+
 
     @staticmethod
     def arches_for_config(buildconfig: Dict):
@@ -308,11 +314,13 @@ class OSBuildImage(BaseTaskHandler):
         # Setup down, talk to composer to create the compose
         kojidata = ComposeRequest.Koji(self.koji_url, self.id)
         cid, bid = client.compose_create(nvr, distro, ireqs, kojidata)
-        self.logger.info("Compose id: %s", cid)
+        self.logger.info("Compose id: %s, Koji build id: %s", cid, bid)
 
         self.logger.debug("Waiting for comose to finish")
         status = client.wait_for_compose(cid)
 
+        self.logger.debug("Compose finished: %s", str(status))
+        self.logger.info("Compose result: %s", status.status)
 
         result = {
             "status": status.status,

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -322,6 +322,9 @@ class OSBuildImage(BaseTaskHandler):
         self.logger.debug("Compose finished: %s", str(status))
         self.logger.info("Compose result: %s", status.status)
 
+        if not status.is_success:
+            raise koji.BuildError(f"Compose failed (id: {cid})")
+
         result = {
             "status": status.status,
             "composer": {

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -326,7 +326,6 @@ class OSBuildImage(BaseTaskHandler):
             raise koji.BuildError(f"Compose failed (id: {cid})")
 
         result = {
-            "status": status.status,
             "composer": {
                 "server": self.composer_url,
                 "id": cid

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -358,6 +358,33 @@ class TestBuilderPlugin(PluginTest):
             self.assertEqual(have, repos)
 
     @httpretty.activate
+    def test_compose_failure(self):
+        # Simulate a failed compose, check exception is raised
+        session = self.mock_session()
+        options = self.mock_options()
+
+        handler = self.plugin.OSBuildImage(1,
+                                           "osbuildImage",
+                                           "params",
+                                           session,
+                                           options)
+
+        args = ["name", "version", "distro",
+                ["image_type"],
+                "fedora-candidate",
+                ["x86_64"],
+                {}]
+
+        url = self.plugin.DEFAULT_COMPOSER_URL
+        composer = MockComposer(url, architectures=["x86_64"])
+        composer.httpretty_regsiter()
+
+        composer.status = "failure"
+
+        with self.assertRaises(koji.BuildError):
+            handler.handler(*args)
+
+    @httpretty.activate
     def test_cli_compose_success(self):
         # Check the basic usage of the plugin as a stand-alone client
         # for the osbuild-composer API

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -346,7 +346,7 @@ class TestBuilderPlugin(PluginTest):
 
         res = handler.handler(*args)
         assert res, "invalid compose result"
-        compose_id = res["composer_id"]
+        compose_id = res["composer"]["id"]
         compose = composer.composes.get(compose_id)
         self.assertIsNotNone(compose)
 

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -24,6 +24,7 @@ class MockComposer:
         self.composes = {}
         self.errors = []
         self.build_id = 1
+        self.status = "success"
 
     def httpretty_regsiter(self):
         httpretty.register_uri(
@@ -62,7 +63,7 @@ class MockComposer:
         self.composes[compose_id] = {
             "request": js,
             "result": compose,
-            "status": "success",
+            "status": self.status,
         }
 
         httpretty.register_uri(


### PR DESCRIPTION
When returning the result from the task handler function, return a more complete and structured object in all cases. Instead of a normal task return with a result dictionary, raise an exception when the compose failed.



Closes #15 