### PR TITLE
Sync with composer 21 changes

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -5,7 +5,7 @@
 To support local development an container `test/Dockerfile` contains
 the environment to test all three plugins. It can be built and run
 via `./run-test.sh`. This will execute the unit tests as well as
-run pylint and ShellCheck on the source code.
+run `pylint` and ShellCheck on the source code.
 
 ## Local integration testing
 
@@ -37,7 +37,7 @@ the koji builder to authorize itself to koji hub.
 sudo ./run-koji-container.sh start
 ```
 
-Koji web will now be running at: http://localhost/koji/
+Koji web will now be running at: http://localhost:8080/koji/
 
 
 Copy the credentials: The TLS certificates for the koji builder plugin
@@ -57,6 +57,16 @@ the container stopped via `ctrl+c`.
 
 ```
 sudo ./run-builder.sh fg
+```
+
+Verify we can talk to koji hub via the koji command line client:
+
+```
+$ koji --server=http://localhost:8080/kojihub --user=osbuild --password=osbuildpass --authtype=password hello
+grüezi, osbuild!
+
+You are using the hub at http://localhost:8080/kojihub
+Authenticated via password
 ```
 
 ### Setup the tags
@@ -92,7 +102,7 @@ ln -s plugins/cli/osbuild.py \
 Now that all is setup a build can be created via:
 
 ```
-koji --server=http://localhost/kojihub \
+koji --server=http://localhost:8080/kojihub \
      --user=kojiadmin \
 	 --password=kojipass \
 	 --authtype=password \
@@ -105,6 +115,38 @@ koji --server=http://localhost/kojihub \
 	 --repo 'http://download.fedoraproject.org/pub/fedora/linux/releases/32/Everything/$arch/os/' \
 	 --image-type qcow2 \
 	 --release 1
+```
+
+### Troubleshooting
+
+Check logs:
+
+```
+sudo podman logs org.osbuild.koji.koji  # koji hub
+sudo podman logs org.osbuild.koji.kdc   # kerberos kdc
+```
+
+Execute into the container:
+
+```
+sudo podman exec -it org.osbuild.koji.koji /bin/bash
+sudo podman exec -it org.osbuild.koji.kdc /bin/bash
+sudo podman exec -it org.osbuild.koji.kojid /bin/bash
+```
+
+### Cleanup
+
+Stopping the container:
+
+```
+sudo ./run-koji-container.sh stop
+
+```
+
+Cleanup of kerberos tickets:
+```
+sudo kdestroy -A
+sudo -u _osbuild-composer kdestroy -A
 ```
 
 ## Useful links

--- a/container/builder/osbuild-koji.conf
+++ b/container/builder/osbuild-koji.conf
@@ -1,7 +1,7 @@
 [composer]
-url = https://composer:8701/
+url = https://composer/
 ssl_cert = /share/worker-crt.pem, /share/worker-key.pem
 ssl_verify = /share/worker-ca.pem
 
 [koji]
-url = https://localhost/kojihub/
+url = https://localhost:4343/kojihub/

--- a/container/hub/hub.conf
+++ b/container/hub/hub.conf
@@ -28,7 +28,7 @@ ProxyDNs = CN=koji,OU=kojiweb,O=RH,L=BE,ST=BE,C=DE
 
 ##  Other options  ##
 LoginCreatesUser = Off
-KojiWebURL = http://localhost/koji
+KojiWebURL = http://localhost:8080/koji
 EmailDomain = kojihub.local
 NotifyOnSuccess = False
 DisableNotifications = True

--- a/make-tags.sh
+++ b/make-tags.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/sh
 set -ux
 
-KOJI="koji --server=http://localhost/kojihub --user=kojiadmin --password=kojipass --authtype=password"
+KOJI="koji --server=http://localhost:8080/kojihub --user=kojiadmin --password=kojipass --authtype=password"
 
 $KOJI add-tag f32
 $KOJI add-tag --parent f32 f32-candidate

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -33,13 +33,14 @@ from koji.daemon import fast_incremental_upload
 from koji.tasks import BaseTaskHandler
 
 
-DEFAULT_COMPOSER_URL = "http://localhost:8701/"
+DEFAULT_COMPOSER_URL = "https://localhost"
 DEFAULT_KOJIHUB_URL = "https://localhost/kojihub"
 DEFAULT_CONFIG_FILES = [
     "/usr/share/koji-osbuild/builder.conf",
     "/etc/koji-osbuild/builder.conf"
 ]
 
+API_BASE = "api/composer-koji/v1/"
 
 # The following classes are a implementation of osbuild composer's
 # koji API. It is based on the corresponding OpenAPI specification
@@ -159,7 +160,8 @@ class ComposeStatus:
 
 class Client:
     def __init__(self, url):
-        self.url = url
+        self.server = url
+        self.url = urllib.parse.urljoin(url, API_BASE)
         self.http = requests.Session()
 
     @staticmethod
@@ -175,7 +177,7 @@ class Client:
         return certs
 
     def compose_create(self, compose_request: ComposeRequest):
-        url = urllib.parse.urljoin(self.url, f"/compose")
+        url = urllib.parse.urljoin(self.url, "compose")
 
         data = compose_request.as_dict()
         res = self.http.post(url, json=data)
@@ -190,7 +192,7 @@ class Client:
         return compose_id, koji_build_id
 
     def compose_status(self, compose_id: str):
-        url = urllib.parse.urljoin(self.url, f"/compose/{compose_id}")
+        url = urllib.parse.urljoin(self.url, f"compose/{compose_id}")
 
         res = self.http.get(url)
 

--- a/run-koji-container.sh
+++ b/run-koji-container.sh
@@ -106,8 +106,8 @@ koji_start() {
   ${CONTAINER_RUNTIME} run -d --name org.osbuild.koji.koji --network org.osbuild.koji \
     -v "${SHARE_DIR}:/share:z" \
     -v "${DATA_DIR}:/mnt:z" \
-    -p 80:80 \
-    -p 443:443 \
+    -p 8080:80 \
+    -p 4343:443 \
     -e POSTGRES_USER=koji \
     -e POSTGRES_PASSWORD=kojipass \
     -e POSTGRES_DB=koji \

--- a/schutzbot/repos/fedora/32/osbuild-composer.repo
+++ b/schutzbot/repos/fedora/32/osbuild-composer.repo
@@ -1,6 +1,6 @@
 [osbuild-mock]
-name=osbuild mock osbuild/osbuild-composer/master-8ccbde8 fedora32
-baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/osbuild/osbuild-composer/master/8ccbde8/fedora32_x86_64
+name=osbuild mock osbuild/osbuild-composer/master-eb01680 fedora32
+baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/osbuild/osbuild-composer/master/eb01680/fedora32_x86_64
 enabled=1
 gpgcheck=0
 # Default dnf repo priority is 99. Lower number means higher priority.

--- a/schutzbot/repos/rhel/8.2/osbuild-composer.repo
+++ b/schutzbot/repos/rhel/8.2/osbuild-composer.repo
@@ -1,6 +1,6 @@
 [osbuild-mock]
-name=osbuild mock osbuild/osbuild-composer/master-8ccbde8 rhel82
-baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/osbuild/osbuild-composer/master/8ccbde8/rhel82_x86_64
+name=osbuild mock osbuild/osbuild-composer/master-eb01680 rhel82
+baseurl=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/osbuild/osbuild-composer/master/eb01680/rhel82_x86_64
 enabled=1
 gpgcheck=0
 # Default dnf repo priority is 99. Lower number means higher priority.

--- a/test/build-container.sh
+++ b/test/build-container.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# this script must be run as root
+if [ $UID != 0 ]; then
+  echo This script must be run as root.
+  exit 1
+fi
+
+source /etc/os-release
+
+podman build \
+       -t koji.hub \
+       -f container/hub/Dockerfile.${ID} .
+
+podman build -t \
+       koji.builder \
+       -f container/builder/Dockerfile.${ID} .

--- a/test/data/osbuild-composer.toml
+++ b/test/data/osbuild-composer.toml
@@ -1,3 +1,11 @@
-[koji.localhost.kerberos]
+[koji]
+allowed_domains = ["localhost", "composer", "::1"]
+ca = "/etc/osbuild-composer/ca-crt.pem"
+
+[koji.servers.localhost.kerberos]
 principal = "osbuild-krb@LOCAL"
 keytab = "/etc/osbuild-composer/client.keytab"
+
+[worker]
+allowed_domains = ["localhost", "composer"]
+ca = "/etc/osbuild-composer/ca-crt.pem"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -56,7 +56,7 @@ greenprint "Copying credentials and certificates"
 sudo test/copy-creds.sh
 
 greenprint "Testing Koji hub API access"
-koji --server=http://localhost/kojihub --user=osbuild --password=osbuildpass --authtype=password hello
+koji --server=http://localhost:8080/kojihub --user=osbuild --password=osbuildpass --authtype=password hello
 
 greenprint "Starting koji builder"
 sudo ./run-builder.sh start

--- a/test/integration/test_koji.py
+++ b/test/integration/test_koji.py
@@ -55,7 +55,7 @@ class TestIntegration(unittest.TestCase):
 
     def setUp(self):
         global_args = dict(
-            server="http://localhost/kojihub",
+            server="http://localhost:8080/kojihub",
             user="kojiadmin",
             password="kojipass",
             authtype="password")

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 import tempfile
+import urllib.parse
 import uuid
 import unittest.mock
 from flexmock import flexmock
@@ -17,9 +18,12 @@ import httpretty
 from plugintest import PluginTest
 
 
+API_BASE = "api/composer-koji/v1/"
+
+
 class MockComposer:
     def __init__(self, url, *, architectures=["x86_64"]):
-        self.url = url
+        self.url = urllib.parse.urljoin(url, API_BASE)
         self.architectures = architectures[:]
         self.composes = {}
         self.errors = []
@@ -29,7 +33,7 @@ class MockComposer:
     def httpretty_regsiter(self):
         httpretty.register_uri(
             httpretty.POST,
-            self.url + "compose",
+            urllib.parse.urljoin(self.url, "compose"),
             body=self.compose_create
         )
 
@@ -68,7 +72,7 @@ class MockComposer:
 
         httpretty.register_uri(
             httpretty.GET,
-            self.url + "compose/" + compose_id,
+            urllib.parse.urljoin(self.url, "compose/" + compose_id),
             body=self.compose_status
         )
 


### PR DESCRIPTION
Upstream composer has introduce a few changes that we need to adapt for:

 - the koji composer API is now exposed on the standard https port (443). Thus koji hub and web need to move to a different pair: 8080 (http) and 4343 (https). Change the scripts and tests for that

 - the koji API gained a prefix 'api/composer-koji/v1/'. Change client and unit tests to use that prefix. Use urljoin to create new APIs

 - composer configuration format (osbuild-composer.toml) has changed and now also includes configuration for the CA and allowed domains

 - update the composer RPM repositories to the commit for the 21 upstream release.