### PR TITLE
Use server instead of url for builder configuration

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,3 +1,15 @@
+# Patches
+
+Patches should be submitted in the form of pull requests at
+[github][github].
+
+# Coding style
+
+Standard PEP-8 formatting is used project wide for Python, with a few
+relaxations, like maximum line length (120). A pylint config file
+[`.pylintrc`](.pylintrc) is provided. The `./run-test.sh` will lint
+the source code using this (see *Testing* below).
+
 # Testing
 
 ## Unit tests
@@ -156,3 +168,5 @@ sudo -u _osbuild-composer kdestroy -A
 - [koji server howto](https://docs.pagure.org/koji/server_howto/)
 - [koji server bootstrap](https://docs.pagure.org/koji/server_bootstrap/)
 - [osbs koji plugin](https://github.com/containerbuildsystem/koji-containerbuild/)
+
+[github][https://github.com/osbuild/koji-osbuild]

--- a/HACKING.md
+++ b/HACKING.md
@@ -18,12 +18,13 @@ Make certificates for osbuild-composer. This is needed to authorize
 clients to use the composer API. There is a script that will create
 the certificates and also copy it to the correct places in `/etc`.
 
-```
+```sh
 sudo test/make-certs.sh
 ```
 
 Build the containers:
-```
+
+```sh
 sudo test/build-container.sh
 ```
 
@@ -33,7 +34,7 @@ Run the infra containers, i.e. the database server, the kerberos kdc,
 and koji hub. This will also create the kerberos keytabs needed for
 the koji builder to authorize itself to koji hub.
 
-```
+```sh
 sudo ./run-koji-container.sh start
 ```
 
@@ -45,7 +46,7 @@ to make authorize requests to composer and the kerberos keytabs
 needed for composer and worker (of composer) to reserve and import the
 build via the koji XML RPC.
 
-```
+```sh
 sudo  test/copy-creds.sh
 ```
 
@@ -55,13 +56,13 @@ Run the koji builder instance can be started. Here `fg` means that
 it will be running in the foreground, so logs can be inspected and
 the container stopped via `ctrl+c`.
 
-```
+```sh
 sudo ./run-builder.sh fg
 ```
 
 Verify we can talk to koji hub via the koji command line client:
 
-```
+```sh
 $ koji --server=http://localhost:8080/kojihub --user=osbuild --password=osbuildpass --authtype=password hello
 grüezi, osbuild!
 
@@ -81,7 +82,7 @@ Specifically:
 A helper script will create a minimum set that is necessary to build
 an image call `Fedora-Cloud` for `f32-candidate`:
 
-```
+```sh
 ./make-tags.sh
 ```
 
@@ -91,7 +92,7 @@ The client plugin needs to be installed either by creating the RPMs
 first via meson, or via a symlink from the checkout to the koji cli
 plugin directory:
 
-```
+```sh
 mkdir -p /usr/lib/python3.8/site-packages/koji/koji_cli_plugins/
 ln -s plugins/cli/osbuild.py \
 	  /usr/lib/python3.8/site-packages/koji/koji_cli_plugins/osbuild.py
@@ -101,7 +102,7 @@ ln -s plugins/cli/osbuild.py \
 
 Now that all is setup a build can be created via:
 
-```
+```sh
 koji --server=http://localhost:8080/kojihub \
      --user=kojiadmin \
 	 --password=kojipass \
@@ -121,14 +122,14 @@ koji --server=http://localhost:8080/kojihub \
 
 Check logs:
 
-```
+```sh
 sudo podman logs org.osbuild.koji.koji  # koji hub
 sudo podman logs org.osbuild.koji.kdc   # kerberos kdc
 ```
 
 Execute into the container:
 
-```
+```sh
 sudo podman exec -it org.osbuild.koji.koji /bin/bash
 sudo podman exec -it org.osbuild.koji.kdc /bin/bash
 sudo podman exec -it org.osbuild.koji.kojid /bin/bash
@@ -138,13 +139,12 @@ sudo podman exec -it org.osbuild.koji.kojid /bin/bash
 
 Stopping the container:
 
-```
+```sh
 sudo ./run-koji-container.sh stop
-
 ```
 
 Cleanup of kerberos tickets:
-```
+```sh
 sudo kdestroy -A
 sudo -u _osbuild-composer kdestroy -A
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@ plugins:
    command line client. This will then use the new XMLRPC API to request a
    new compose.
 
+## Configuration
+
+The builder plugin needs to be configured via a `builder.conf` file that
+can be located in either `/usr/share/koji-osbuild` or `/etc/koji-osbuild`.
+
+```ini
+[composer]
+# The host, port and transport (https vs http) of osbuild composer
+# NB: The 'https' transport is required for SSL/TLS authorization
+server = https://composer.osbuild.org
+
+# Authorization via client side certificates: can be either a pair of
+# certificate and key files separated by comma or a file combining both.
+ssl_cert = /share/worker-crt.pem, /share/worker-key.pem
+
+# Verification of the server side: either a boolean (True / False) to
+# enable or disable verification, or a path to a CA_BUNDLE file or a
+# directory containing certificates of trusted CAs.
+ssl_verify = /share/worker-ca.pem
+
+[koji]
+# The URL to the koji hub XML-RPC endpoint
+server = https://koji.fedoraproject.org/kojihub
+```
+
+
 ## Development
 
 See [`HACKING.md`](HACKING.md) for how to develop and test this project.

--- a/container/builder/osbuild-koji.conf
+++ b/container/builder/osbuild-koji.conf
@@ -1,7 +1,7 @@
 [composer]
-url = https://composer/
+server = https://composer/
 ssl_cert = /share/worker-crt.pem, /share/worker-key.pem
 ssl_verify = /share/worker-ca.pem
 
 [koji]
-url = https://localhost:4343/kojihub/
+server = https://localhost:4343/kojihub/

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -221,14 +221,14 @@ class OSBuildImage(BaseTaskHandler):
 
         cfg = configparser.ConfigParser()
         cfg.read_dict({
-            "composer": {"url": DEFAULT_COMPOSER_URL},
-            "koji": {"url": DEFAULT_KOJIHUB_URL}
+            "composer": {"server": DEFAULT_COMPOSER_URL},
+            "koji": {"server": DEFAULT_KOJIHUB_URL}
         })
 
         cfg.read(DEFAULT_CONFIG_FILES)
 
-        self.composer_url = cfg["composer"]["url"]
-        self.koji_url = cfg["koji"]["url"]
+        self.composer_url = cfg["composer"]["server"]
+        self.koji_url = cfg["koji"]["server"]
         self.client = Client(self.composer_url)
 
         self.logger.debug("composer: %s", self.composer_url)

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -267,12 +267,12 @@ class TestBuilderPlugin(PluginTest):
 
             cfg = configparser.ConfigParser()
             cfg["composer"] = {
-                "url": composer_url,
+                "server": composer_url,
                 "ssl_cert": ssl_cert,
                 "ssl_verify": ssl_verify
             }
             cfg["koji"] = {
-                "url": koji_url
+                "server": koji_url
             }
 
             cfgfile = os.path.abspath(os.path.join(tmp, "ko.cfg"))


### PR DESCRIPTION
Mostly to be more in line with how things are called in all other koji configuration files. Updates to the docs.