### PR TITLE
Integrate spell checking via codespell and fix uncovered mistakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,12 @@ jobs:
       uses: ludeeus/action-shellcheck@0.5.0
       with:
         severity: warning
+
+  codespell:
+    name: "Spell check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: codespell-project/actions-codespell@master
+        with:
+          skip: ./.git,build

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ plugin is enabled by adding `osbuild` to the `Plugins` directive. The
 *builder*: configuration file at `/etc/kojid/kojid.conf`. Here `osbuild`
 needs to be added to the `plugin` directive.
 For an example, see the test container configuration files
-[`hub.conf`](test/container/hub/hub.conf`) for the hub and
-[`kojid.conf`](`container/builder/kojid.conf`) for the builder.
+[`hub.conf`](test/container/hub/hub.conf) for the hub and
+[`kojid.conf`](container/builder/kojid.conf) for the builder.
 
 Additionally, an osbuild-composer instance, at least version 21, with the
 koji API enabled needs to be running and reachable via TCP from the host

--- a/test/container/hub/kojiweb.conf
+++ b/test/container/hub/kojiweb.conf
@@ -2,7 +2,7 @@
 Alias /koji "/usr/share/koji-web/scripts/wsgi_publisher.py"
 #(configuration goes in /etc/kojiweb/web.conf)
 
-# Python 3 Cheetah expectes unicode everywhere, apache's default lang is C
+# Python 3 Cheetah expects unicode everywhere, apache's default lang is C
 # which is not sufficient to open our templates
 WSGIDaemonProcess koji lang=C.UTF-8
 WSGIProcessGroup koji


### PR DESCRIPTION
Integrate the codespell github action to spell check the source code in CI. Fix uncovered mistakes and also some links in `README.md`.