### PR TITLE
test/builder: avoid using list in keyword argument

### DIFF
--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -22,9 +22,9 @@ API_BASE = "api/composer-koji/v1/"
 
 
 class MockComposer:
-    def __init__(self, url, *, architectures=["x86_64"]):
+    def __init__(self, url, *, architectures=None):
         self.url = urllib.parse.urljoin(url, API_BASE)
-        self.architectures = architectures[:]
+        self.architectures = architectures or ["x86_64"]
         self.composes = {}
         self.errors = []
         self.build_id = 1


### PR DESCRIPTION
Although in that specific use case it was fine, since the list was copied before usage, pylint in newer versions was unhappy.