### PR TITLE
spec: require python3-jsonschema (hub plugin)

### DIFF
--- a/koji-osbuild.spec.in
+++ b/koji-osbuild.spec.in
@@ -23,6 +23,7 @@ Koji integration for osbuild composer.
 Summary:        Koji hub plugin for osbuild composer integration
 Requires:       %{name} = %{version}-%{release}
 Requires:       koji-hub
+Requires:       python3-jsonschema
 
 %description    hub
 Koji hub plugin for osbuild composer integration.


### PR DESCRIPTION
The hub plugin uses jsonschema, so it must explicitly depend on it.