### PR TITLE
invert missing arch support logic

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -319,7 +319,7 @@ class OSBuildImage(BaseTaskHandler):
         # Architectures
         tag_arches = self.arches_for_config(buildconfig)
         arches = set(arches)
-        diff = tag_arches - arches
+        diff = arches - tag_arches
         if diff:
             raise koji.BuildError("Unsupported architecture(s): " + str(diff))
 


### PR DESCRIPTION
I expect that this should be a subset of tag architectures not reverse.