### PR TITLE
Fix support architecture check in builder plugin

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -319,7 +319,7 @@ class OSBuildImage(BaseTaskHandler):
         # Architectures
         tag_arches = self.arches_for_config(buildconfig)
         arches = set(arches)
-        diff = tag_arches - arches
+        diff = arches - tag_arches
         if diff:
             raise koji.BuildError("Unsupported architecture(s): " + str(diff))
 

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -213,7 +213,7 @@ class TestBuilderPlugin(PluginTest):
         }
 
         build_config = {
-            "arches": "x86_64"
+            "arches": "s390x aarch64 ppc64le x86_64"
         }
 
         repo_info = {


### PR DESCRIPTION
This is based on PR #30. The actual fix, done by @tkopecek is exactly the same, only the commit message was modified and a test added that would have caught the bug (and should help prevent regressions).

See the commit message for details. Many thanks @tkopecek