### PR TITLE
plugins: ability to skip the tagging

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -416,7 +416,9 @@ class OSBuildImage(BaseTaskHandler):
         if not status.is_success:
             raise koji.BuildError(f"Compose failed (id: {cid})")
 
-        self.tag_build(target_info["dest_tag"], bid)
+        # Build was successful, tag it
+        if not opts.get('skip_tag'):
+            self.tag_build(target_info["dest_tag"], bid)
 
         result = {
             "composer": {

--- a/plugins/cli/osbuild.py
+++ b/plugins/cli/osbuild.py
@@ -30,6 +30,8 @@ def parse_args(argv):
     parser.add_option("--image-type", metavar="TYPE",
                       help='Request an image-type [default: qcow2]',
                       type=str, action="append", default=[])
+    parser.add_option("--skip-tag", action="store_true",
+                      help=_("Do not attempt to tag package"))
     parser.add_option("--wait", action="store_true",
                       help=_("Wait on the image creation, even if running in the background"))
 
@@ -77,6 +79,9 @@ def handle_osbuild_image(options, session, argv):
 
     if args.repo:
         opts["repo"] = args.repo
+
+    if args.skip_tag:
+        opts["skip_tag"] = True
 
     # Do some early checks to be able to give quick feedback
     check_target(session, target)

--- a/plugins/hub/osbuild.py
+++ b/plugins/hub/osbuild.py
@@ -64,6 +64,10 @@ OSBUILD_IMAGE_SCHEMA = {
                 "release": {
                     "type": "string",
                     "description": "Release override"
+                },
+                "skip_tag": {
+                    "type": "boolean",
+                    "description": "Omit tagging the result"
                 }
             }
         }

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -83,7 +83,8 @@ class TestCliPlugin(PluginTest):
             # optional keyword arguments
             "--repo", "https://first.repo",
             "--repo", "https://second.repo",
-            "--release", "20200202.n2"
+            "--release", "20200202.n2",
+            "--skip-tag"
         ]
 
         expected_args = ["name", "version", "distro",
@@ -93,7 +94,8 @@ class TestCliPlugin(PluginTest):
 
         expected_opts = {
             "release": "20200202.n2",
-            "repo": ["https://first.repo", "https://second.repo"]
+            "repo": ["https://first.repo", "https://second.repo"],
+            "skip_tag": True
         }
 
         task_result = {"compose_id": "42", "build_id": 23}

--- a/test/unit/test_hub.py
+++ b/test/unit/test_hub.py
@@ -43,7 +43,8 @@ class TestHubPlugin(PluginTest):
         context = self.mock_koji_context()
 
         opts = {"repo": ["repo1", "repo2"],
-                "release": "1.2.3"}
+                "release": "1.2.3",
+                "skip_tag": True}
         args = ["name", "version", "distro",
                 ["image_type"],
                 "target",


### PR DESCRIPTION
Add a new command line option `--skip-tag` that will skip tagging after a successful build. The help text is copied from the same option of other sub-commands in the koji client. The hub plugin's jsonschema was updated accordingly, and the builder plugin will skip the tag if the option was requested.
Tests were added or augmented for all three plugins to test the new option.