### PR TITLE
test: use quay mirror for the postgres container

### DIFF
--- a/test/run-koji-container.sh
+++ b/test/run-koji-container.sh
@@ -69,7 +69,7 @@ koji_start() {
     -e POSTGRES_USER=koji \
     -e POSTGRES_PASSWORD=kojipass \
     -e POSTGRES_DB=koji \
-    docker.io/library/postgres:12-alpine
+    quay.io/osbuild/postgres:v1
 
   ${CONTAINER_RUNTIME} run -d --name org.osbuild.koji.kdc \
     --hostname org.osbuild.koji.kdc \


### PR DESCRIPTION
The official postgres container image is fetched from docker.io, which recently introduced rate limiting, which makes introduces possible CI error if we run into this limit. Instead use a custom mirror[1] of the official image, hosted on quay.io[2]. As a side effect this updates the posgres version from 12 to 13.

[1] osbuild/containers@7db3c68
[2] quay.io/osbuild/postgres:v1