### PR TITLE
Upload logs and the compose status

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -144,7 +144,9 @@ class ComposeStatus:
     def from_dict(cls, data: Dict):
         status = data["status"].lower()
         koji_task_id = data["koji_task_id"]
-        images = [ImageStatus(s["status"].lower()) for s in data["image_statuses"]]
+        images = [
+            ImageStatus(s["status"].lower()) for s in data["image_statuses"]
+        ]
         return cls(status, images, koji_task_id)
 
     def as_dict(self):

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -147,6 +147,15 @@ class ComposeStatus:
         images = [ImageStatus(s["status"].lower()) for s in data["image_statuses"]]
         return cls(status, images, koji_task_id)
 
+    def as_dict(self):
+        return {
+            "status": self.status,
+            "koji_task_id": self.koji_task_id,
+            "image_statuses": [
+                {"status": status.value} for status in self.images
+            ]
+        }
+
     @property
     def is_finished(self):
         if self.is_success:
@@ -391,7 +400,7 @@ class OSBuildImage(BaseTaskHandler):
         self.logger.debug("Waiting for comose to finish")
         status = client.wait_for_compose(cid)
 
-        self.logger.debug("Compose finished: %s", str(status))
+        self.logger.debug("Compose finished: %s", str(status.as_dict()))
         self.logger.info("Compose result: %s", status.status)
 
         self.attach_logs(cid, ireqs)

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -273,7 +273,7 @@ class OSBuildImage(BaseTaskHandler):
             self.client.http.verify = val
             self.logger.debug("ssl verify: %s", val)
 
-    def upload_meta_data(self, data: Dict, name: str):
+    def upload_json(self, data: Dict, name: str):
         fd = io.StringIO()
         json.dump(data, fd, indent=4, sort_keys=True)
         fd.seek(0)
@@ -296,18 +296,9 @@ class OSBuildImage(BaseTaskHandler):
 
         ilogs = zip(logs.image_logs, ireqs)
         for log, ireq in ilogs:
-            name = "%s-%s" % (ireq.architecture, ireq.image_type)
-            self.logger.debug("Uploading logs for %s", name)
-            fd = io.StringIO()
-            json.dump(log, fd, indent=4, sort_keys=True)
-            fd.seek(0)
-            path = koji.pathinfo.taskrelpath(self.id)
-            fast_incremental_upload(self.session,
-                                    name + ".log.json",
-                                    fd,
-                                    path,
-                                    3,  # retries
-                                    self.logger)
+            name = "%s-%s.log" % (ireq.architecture, ireq.image_type)
+            self.logger.debug("Uploading logs: %s", name)
+            self.upload_json(log, name)
 
     @staticmethod
     def arches_for_config(buildconfig: Dict):
@@ -392,7 +383,7 @@ class OSBuildImage(BaseTaskHandler):
         kojidata = ComposeRequest.Koji(self.koji_url, self.id)
         request = ComposeRequest(nvr, distro, ireqs, kojidata)
 
-        self.upload_meta_data(request.as_dict(), "compose-request")
+        self.upload_json(request.as_dict(), "compose-request")
 
         cid, bid = client.compose_create(request)
         self.logger.info("Compose id: %s, Koji build id: %s", cid, bid)

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -318,8 +318,7 @@ class OSBuildImage(BaseTaskHandler):
 
         # Architectures
         tag_arches = self.arches_for_config(buildconfig)
-        arches = set(arches)
-        diff = arches - tag_arches
+        diff = set(arches) - tag_arches
         if diff:
             raise koji.BuildError("Unsupported architecture(s): " + str(diff))
 

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -405,6 +405,7 @@ class OSBuildImage(BaseTaskHandler):
         self.logger.debug("Compose finished: %s", str(status.as_dict()))
         self.logger.info("Compose result: %s", status.status)
 
+        self.upload_json(status.as_dict(), "compose-status")
         self.attach_logs(cid, ireqs)
 
         if not status.is_success:

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -479,6 +479,7 @@ class TestBuilderPlugin(PluginTest):
         for arch in arches:
             self.uploads.assert_upload(f"{arch}-image_type.log.json")
         self.uploads.assert_upload("compose-request.json")
+        self.uploads.assert_upload("compose-status.json")
 
         build_id = res["koji"]["build"]
         # build should have been tagged
@@ -507,6 +508,7 @@ class TestBuilderPlugin(PluginTest):
 
         self.uploads.assert_upload("compose-request.json")
         self.uploads.assert_upload("x86_64-image_type.log.json")
+        self.uploads.assert_upload("compose-status.json")
         # build must not have been tagged
         self.assertEqual(len(session.host.tags), 0)
 

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -89,7 +89,7 @@ class MockComposer:
             "status": compose["status"],
             "koji_task_id": compose["request"]["koji"]["task_id"],
             "image_statuses": [
-                {"status": compose["status"] for _ in ireqs}
+                {"status": compose["status"]} for _ in ireqs
             ]
         }
         return [200, response_headers, json.dumps(result)]


### PR DESCRIPTION
Use the new composer API to fetch and upload logs. Additionally also upload the compose status and update it throughout the build.