### PR TITLE
Use dynamic build id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     - name: "Clone Repository"
       uses: actions/checkout@v2
     - name: "Run pylint"
-      uses: osbuild/koji-osbuild/test@master
+      uses: osbuild/koji-osbuild/test@main
       with:
         run: |
           pylint plugins/**/*.py test/**/*.py
@@ -22,7 +22,7 @@ jobs:
     - name: "Clone Repository"
       uses: actions/checkout@v2
     - name: "Run unit tests"
-      uses: osbuild/koji-osbuild/test@master
+      uses: osbuild/koji-osbuild/test@main
       with:
         run: |
           pytest --cov-report=xml --cov=osbuild test/unit/

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -61,11 +61,11 @@ class MockComposer:
         compose_id = str(uuid.uuid4())
         build_id = self.next_build_id()
         compose = {
-            "id": compose_id,
-            "koji_build_id": build_id,
+            "id": compose_id
         }
 
         self.composes[compose_id] = {
+            "build_id": build_id,
             "request": js,
             "result": compose,
             "status": self.status,
@@ -98,6 +98,7 @@ class MockComposer:
         result = {
             "status": compose["status"],
             "koji_task_id": compose["request"]["koji"]["task_id"],
+            "koji_build_id": compose["build_id"],
             "image_statuses": [
                 {"status": compose["status"]} for _ in ireqs
             ]


### PR DESCRIPTION
Instead of getting the `koji_build_id` from the direct reply of the compose request call, use the one returned in the compose status.

The reason behind this is that composer was changed so that the `CGInitBuild` call to koji is now being done by a worker and not composer itself. This means that once the compose request call returns, the build id is not yet known. In composer release 24, the compose request call internally waits for the worker that does the `CGInitBuild` API call, but that will be changed, and the `koji_build_id` will then not be returned from the compose request API call anymore. This prepares for that. The tests are also adapted to simulate the new behavior.

NB: this makes composer 24 a dependency, since the build id is taken from the `ComposeStatus`, which was only added there.