### PR TITLE
builder: attach koji init/import logs

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -177,13 +177,17 @@ class ComposeStatus:
 
 
 class ComposeLogs:
-    def __init__(self, image_logs: List):
+    def __init__(self, image_logs: List, import_logs, init_logs):
         self.image_logs = image_logs
+        self.koji_import_logs = import_logs
+        self.koji_init_logs = init_logs
 
     @classmethod
     def from_dict(cls, data: Dict):
         image_logs = data["image_logs"]
-        return cls(image_logs)
+        import_logs = data["koji_import_logs"]
+        init_logs = data["koji_init_logs"]
+        return cls(image_logs, import_logs, init_logs)
 
 
 class Client:
@@ -313,6 +317,12 @@ class OSBuildImage(BaseTaskHandler):
         except koji.GenericError as e:
             self.logger.warning("Failed to fetch logs: %s", str(e))
             return
+
+        if logs.koji_init_logs:
+            self.upload_json(logs.koji_init_logs, "koji-init.log")
+
+        if logs.koji_import_logs:
+            self.upload_json(logs.koji_import_logs, "koji-import.log")
 
         ilogs = zip(logs.image_logs, ireqs)
         for log, ireq in ilogs:

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -117,9 +117,11 @@ class MockComposer:
 
         ireqs = compose["request"]["image_requests"]
         result = {
+            "koji_init_logs": {"log": "yes, please!"},
             "image_logs": [
                 {"osbuild": "log log log"} for _ in ireqs
-            ]
+            ],
+            "koji_import_logs": {"log": "yes, indeed!"},
         }
         return [200, response_headers, json.dumps(result)]
 
@@ -481,6 +483,8 @@ class TestBuilderPlugin(PluginTest):
             self.uploads.assert_upload(f"{arch}-image_type.log.json")
         self.uploads.assert_upload("compose-request.json")
         self.uploads.assert_upload("compose-status.json")
+        self.uploads.assert_upload("koji-init.log.json")
+        self.uploads.assert_upload("koji-import.log.json")
 
         build_id = res["koji"]["build"]
         # build should have been tagged


### PR DESCRIPTION
De-serialize the koji init and import logs, required fields in the `ComposeLogs`, and if non-empty, attach them to the task. Update the tests to check for the presence of these logs.