### PR TITLE
Match container versions to the host

### DIFF
--- a/test/build-container.sh
+++ b/test/build-container.sh
@@ -12,9 +12,11 @@ fi
 source /etc/os-release
 
 podman build \
+       --build-arg version=${VERSION_ID} \
        -t koji.hub \
        -f ${TEST_PATH}/container/hub/Dockerfile.${ID} $TEST_PATH
 
-podman build -t \
-       koji.builder \
+podman build \
+       --build-arg version=${VERSION_ID} \
+       -t koji.builder \
        -f ${TEST_PATH}/container/builder/Dockerfile.${ID} $TEST_PATH

--- a/test/container/builder/Dockerfile.fedora
+++ b/test/container/builder/Dockerfile.fedora
@@ -1,4 +1,6 @@
-FROM docker.io/library/fedora:latest
+ARG version=latest
+
+FROM docker.io/library/fedora:$version
 
 RUN dnf -y upgrade \
     && dnf -y \

--- a/test/container/builder/Dockerfile.rhel
+++ b/test/container/builder/Dockerfile.rhel
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+ARG version=latest
+
+FROM registry.access.redhat.com/ubi8/ubi:$version
 
 COPY container/rhel.repo /etc/yum.repos.d/
 COPY container/brew.repo /etc/yum.repos.d/

--- a/test/container/builder/run-kojid.sh
+++ b/test/container/builder/run-kojid.sh
@@ -7,6 +7,7 @@ if ls /share/rpms/*.rpm 1> /dev/null 2>&1; then
           /share/rpms/koji-osbuild-builder-*.rpm
 else
   echo "Using local plugin"
+  mkdir -p /usr/lib/koji-builder-plugins/
   cp /share/plugins/builder/osbuild.py /usr/lib/koji-builder-plugins/
 fi
 

--- a/test/container/hub/Dockerfile.fedora
+++ b/test/container/hub/Dockerfile.fedora
@@ -1,11 +1,17 @@
-FROM quay.io/osbuild/koji:v1
+FROM docker.io/library/fedora:latest
+
+# koji db schema is in docs, remove nodocs from from dnf config
+RUN sed  -i '/^tsflags=nodocs$/d' /etc/dnf/dnf.conf
 
 RUN dnf -y upgrade \
     && dnf -y \
             --setopt=fastestmirror=True \
             --setopt=install_weak_deps=False \
             install \
+	koji-hub \
 	koji-web \
+        postgresql \
+        mod_ssl \
 	python3-jsonschema \
 	&& dnf clean all
 

--- a/test/container/hub/Dockerfile.fedora
+++ b/test/container/hub/Dockerfile.fedora
@@ -1,4 +1,6 @@
-FROM docker.io/library/fedora:latest
+ARG version=latest
+
+FROM docker.io/library/fedora:$version
 
 # koji db schema is in docs, remove nodocs from from dnf config
 RUN sed  -i '/^tsflags=nodocs$/d' /etc/dnf/dnf.conf

--- a/test/container/hub/Dockerfile.rhel
+++ b/test/container/hub/Dockerfile.rhel
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+ARG version=latest
+
+FROM registry.access.redhat.com/ubi8/ubi:$version
 
 COPY container/rhel.repo /etc/yum.repos.d/
 COPY container/brew.repo /etc/yum.repos.d/

--- a/test/container/hub/run-hub.sh
+++ b/test/container/hub/run-hub.sh
@@ -7,6 +7,7 @@ if ls /share/rpms/*.rpm 1> /dev/null 2>&1; then
           /share/rpms/koji-osbuild-hub-*.rpm
 else
   echo "Using local plugin"
+  mkdir -p /usr/lib/koji-hub-plugins/
   cp /share/plugins/hub/osbuild.py /usr/lib/koji-hub-plugins/
 fi
 

--- a/test/make-tags.sh
+++ b/test/make-tags.sh
@@ -13,4 +13,6 @@ $KOJI add-target f32-candidate f32-build f32-candidate
 $KOJI add-pkg --owner kojiadmin f32-candidate Fedora-Cloud
 $KOJI add-pkg --owner kojiadmin f32-candidate RHEL-Cloud
 
+$KOJI add-pkg --owner kojiadmin f32-candidate Fedora-IoT
+
 $KOJI regen-repo f32-build

--- a/test/run-builder.sh
+++ b/test/run-builder.sh
@@ -25,6 +25,17 @@ builder_start() {
   GATEWAY_IP=$(${CONTAINER_RUNTIME} network inspect org.osbuild.koji | jq -r ".[0].plugins[0].ipam.ranges[0][0].gateway")
   echo "Gateway IP is $GATEWAY_IP"
 
+  # maybe copy the 'builder' plugin to the share dir
+  PLUGIN_NAME="builder"
+  PLUGIN_PATH="plugins/${PLUGIN_NAME}"
+  if [[ -f "${PLUGIN_PATH}/osbuild.py" ]]; then
+    PLUGIN_DEST="${SHARE_DIR}/${PLUGIN_PATH}"
+
+    echo "[COPY] '${PLUGIN_NAME}' plugin to ${PLUGIN_DEST}"
+    mkdir -p "${PLUGIN_DEST}"
+    cp "${PLUGIN_PATH}/osbuild.py" "${PLUGIN_DEST}"
+  fi
+
   ${CONTAINER_RUNTIME} run ${CONTAINER_FLAGS} \
     --name org.osbuild.koji.builder --network org.osbuild.koji \
     -v "${SHARE_DIR}:/share:z" \

--- a/test/run-builder.sh
+++ b/test/run-builder.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 set -euo pipefail
 
-TEST_PATH=${2:-test}
+TEST_PATH=${2:-${PWD}/test}
 SHARE_DIR=${SHARE_DIR:-/tmp/osbuild-composer-koji-test}
 DATA_DIR=${DATA_DIR:-/var/tmp/osbuild-koji-data}
 

--- a/test/run-koji-container.sh
+++ b/test/run-koji-container.sh
@@ -108,6 +108,17 @@ koji_start() {
   # koji data
   mkdir -p ${DATA_DIR}/koji/{packages,repos,work,scratch,repos-dist}
 
+  # maybe copy the 'hub' plugin to the share dir
+  PLUGIN_NAME="hub"
+  PLUGIN_PATH="plugins/${PLUGIN_NAME}"
+  if [[ -f "${PLUGIN_PATH}/osbuild.py" ]]; then
+    PLUGIN_DEST="${SHARE_DIR}/${PLUGIN_PATH}"
+
+    echo "[COPY] '${PLUGIN_NAME}' plugin to ${PLUGIN_DEST}"
+    mkdir -p "${PLUGIN_DEST}"
+    cp "${PLUGIN_PATH}/osbuild.py" "${PLUGIN_DEST}"
+  fi
+
   ${CONTAINER_RUNTIME} run -d --name org.osbuild.koji.koji --network org.osbuild.koji \
     -v "${SHARE_DIR}:/share:z" \
     -v "${DATA_DIR}:/mnt:z" \


### PR DESCRIPTION
The main reason behind this is that currently we were using `latest`, which is a moving target. Now, the containers are matched to the host. This should also allow us to use the testing infra in gating tests, assuming that the gating machines run the target operating system version. See individual commits for more details.

Additionally make a few minor changes to re-enable local development.