### PR TITLE
test: replace docker.io with fedora's registry

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/fedora:latest
+FROM registry.fedoraproject.org/fedora:latest
 
 RUN dnf -y upgrade \
     && dnf -y \

--- a/test/container/builder/Dockerfile.fedora
+++ b/test/container/builder/Dockerfile.fedora
@@ -1,6 +1,6 @@
 ARG version=latest
 
-FROM docker.io/library/fedora:$version
+FROM registry.fedoraproject.org/fedora:$version
 
 RUN dnf -y upgrade \
     && dnf -y \

--- a/test/container/hub/Dockerfile.fedora
+++ b/test/container/hub/Dockerfile.fedora
@@ -1,6 +1,6 @@
 ARG version=latest
 
-FROM docker.io/library/fedora:$version
+FROM registry.fedoraproject.org/fedora:$version
 
 # koji db schema is in docs, remove nodocs from from dnf config
 RUN sed  -i '/^tsflags=nodocs$/d' /etc/dnf/dnf.conf


### PR DESCRIPTION
In order to avoid running into docker.io's new download limit, use the container directly from registry.fedoraproject.org.