### PR TITLE
Fetch and attach the manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 build/
 **/__pycache__/
 
+.vscode/
+
 .coverage
 coverage.xml


### PR DESCRIPTION
Add support for fetching manifests via the compose/<id>/manifests API endpoint. A failure to fetch them is not critical, since it is possible the manifests don't exist, e.g. when depsolving fails. The manifest is attached per image request.