### PR TITLE
plugin/cli: remove type annotation

### DIFF
--- a/plugins/cli/osbuild.py
+++ b/plugins/cli/osbuild.py
@@ -48,7 +48,7 @@ def parse_args(argv):
     return opts
 
 
-def check_target(session, name: str):
+def check_target(session, name):
     """Check the target with name exists and has a destination tag"""
 
     target = session.getBuildTarget(name)


### PR DESCRIPTION
Remove the single string type annotation; it does not gain us much and seems to be the only thing missing for python 2.7 (RHEL 7) support.