### PR TITLE
Lower task weight

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -420,7 +420,7 @@ class Client:
 
 class OSBuildImage(BaseTaskHandler):
     Methods = ['osbuildImage']
-    _taskWeight = 2.0
+    _taskWeight = 0.2
 
     def __init__(self, task_id, method, params, session, options):
         super().__init__(task_id, method, params, session, options)


### PR DESCRIPTION
It similar to BuildTask - so it doesn't do much on the builder and
doesn't use a lot of resources. It makes sense to have much lower weight
for this type of task.