### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [pull_request, push]
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
 
 jobs:
   pylint:

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -1,7 +1,11 @@
 # inspired by rhinstaller/anaconda
 
 name: Trigger GitLab CI
-on: [push, pull_request_target]
+on:
+  pull_request_target:
+  push:
+    branches:
+      - main
 
 jobs:
   pr-info:


### PR DESCRIPTION
There isn't a requirements.txt file for the Python dependencies so only GitHub Actions will be monitored and updated. 