### PR TITLE
devcontainer: add initial support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,48 @@
+FROM fedora:latest
+RUN dnf install -y \
+    bat \
+    findutils \
+    fish \
+    fpaste \
+    git \
+    glibc-langpack-en \
+    hostname \
+    ipython3 \
+    jq \
+    koji \
+    koji-builder \
+    koji-hub \
+    koji-utils \
+    lsof \
+    make \
+    podman \
+    postgresql \
+    pylint \
+    python3-autopep8 \
+    python3-devel \
+    python3-docutils \
+    python3-enchant \
+    python3-flexmock \
+    python3-httpretty \
+    python3-iniparse \
+    python3-jsonschema \
+    python3-koji \
+    python3-mako \
+    python3-pip \
+    python3-pycodestyle \
+    python3-pylint \
+    python3-pytest \
+    python3-pytest-cov \
+    python3-pyyaml \
+    python3-requests \
+    qemu-img \
+    qemu-system-x86 \
+    rpm-build \
+    rpmlint \
+    ShellCheck \
+    skopeo \
+    strace \
+    the_silver_searcher \
+    tree
+
+WORKDIR /workspaces/koji-osbuild

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+  "name": "koji-osbuild",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+  },
+  "mounts": [
+    "source=osbuild-share,target=/root/.local/share,type=volume"
+  ],
+  "runArgs": [
+    "--privileged"
+  ],
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/fish",
+    "python.pythonPath": "/usr/bin/python",
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pyTestEnabled": true,
+    "python.testing.pyTestArgs": [
+      "test"
+    ]
+  },
+  "extensions": [
+    "editorconfig.editorconfig",
+    "laurenttreguier.rpm-spec",
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "ms-vscode-remote.remote-containers"
+  ]
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,12 +4,21 @@ set -euo pipefail
 SHELLCHECK_SEVERITY=${SHELLCHECK_SEVERITY:-warning}
 
 run_test() {
+  if [ -f /.dockerenv ]; then
+    eval "$1"
+    return
+  fi
+
   podman run --rm -it -v "$(pwd)":/github/workspace:z --env "GITHUB_WORKSPACE=/github/workspace" koji.test "$1"
 }
 
-pushd test
-podman build -t koji.test -f Dockerfile .
-popd
+if [ ! -f /.dockerenv ]; then
+  pushd test
+  podman build -t koji.test -f Dockerfile .
+  popd
+else
+  echo "Container detected, direct mode."
+fi
 
 SCRIPTS="$(git ls-files --exclude='*.sh' --ignored | xargs echo)"
 


### PR DESCRIPTION
Add support for coding in VS Code via a Dev Container. Allow `run-test.sh` to run from within the container.