### PR TITLE
Support for oauth2 authentication

### DIFF
--- a/koji-osbuild.spec
+++ b/koji-osbuild.spec
@@ -134,6 +134,7 @@ Requires:       koji
 Requires:       krb5-workstation
 Requires:       openssl
 Requires:       osbuild-composer >= 22
+Requires:       osbuild-composer-tests
 Requires:       podman
 Requires:       podman-plugins
 

--- a/koji-osbuild.spec
+++ b/koji-osbuild.spec
@@ -71,6 +71,7 @@ install -m 0755 -vd                                             %{buildroot}/%{_
 install -m 0755 -vp test/make-certs.sh                          %{buildroot}/%{_libexecdir}/%{name}-tests/
 install -m 0755 -vp test/build-container.sh                     %{buildroot}/%{_libexecdir}/%{name}-tests/
 install -m 0755 -vp test/run-koji-container.sh                  %{buildroot}/%{_libexecdir}/%{name}-tests/
+install -m 0755 -vp test/run-openid.sh                          %{buildroot}/%{_libexecdir}/%{name}-tests/
 install -m 0755 -vp test/copy-creds.sh                          %{buildroot}/%{_libexecdir}/%{name}-tests/
 install -m 0755 -vp test/run-builder.sh                         %{buildroot}/%{_libexecdir}/%{name}-tests/
 install -m 0755 -vp test/make-tags.sh                           %{buildroot}/%{_libexecdir}/%{name}-tests/

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -24,7 +24,7 @@ import time
 import urllib.parse
 
 from string import Template
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import requests
 import koji
@@ -209,11 +209,20 @@ class Client:
 
         return certs
 
+    def request(self, method: str, url: str, js: Optional[Dict] = None):
+        return self.http.request(method, url, json=js)
+
+    def get(self, url: str) -> requests.Response:
+        return self.request("GET", url)
+
+    def post(self, url: str, js: Optional[Dict] = None):
+        return self.request("POST", url, js=js)
+
     def compose_create(self, compose_request: ComposeRequest):
         url = urllib.parse.urljoin(self.url, "compose")
 
         data = compose_request.as_dict()
-        res = self.http.post(url, json=data)
+        res = self.post(url, js=data)
 
         if res.status_code != 201:
             body = res.content.decode("utf-8").strip()
@@ -226,7 +235,7 @@ class Client:
     def compose_status(self, compose_id: str):
         url = urllib.parse.urljoin(self.url, f"compose/{compose_id}")
 
-        res = self.http.get(url)
+        res = self.get(url)
 
         if res.status_code != 200:
             body = res.content.decode("utf-8").strip()
@@ -238,7 +247,7 @@ class Client:
     def compose_logs(self, compose_id: str):
         url = urllib.parse.urljoin(self.url, f"compose/{compose_id}/logs")
 
-        res = self.http.get(url)
+        res = self.get(url)
 
         if res.status_code != 200:
             body = res.content.decode("utf-8").strip()
@@ -250,7 +259,7 @@ class Client:
     def compose_manifests(self, compose_id: str):
         url = urllib.parse.urljoin(self.url, f"compose/{compose_id}/manifests")
 
-        res = self.http.get(url)
+        res = self.get(url)
 
         if res.status_code != 200:
             body = res.content.decode("utf-8").strip()

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -21,7 +21,7 @@ function retry {
 # Variables for where to find osbuild-composer RPMs to test against
 DNF_REPO_BASEURL=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com
 OSBUILD_COMMIT=bb30ffa0629e16ecff103aaaeb7e931f3f8ff79e             # release 46
-OSBUILD_COMPOSER_COMMIT=b5987a5ca51826f29a3bce742d693a55f16f016f    # commit newer than release 30 (we need one with rhel-8-cdn)
+OSBUILD_COMPOSER_COMMIT=f3d0a4ac89561f3970e18ef28a868f0b43ba98f1    # commit with mock-openid enhancements
 
 # Get OS details.
 source /etc/os-release

--- a/test/container/builder/osbuild-koji.conf
+++ b/test/container/builder/osbuild-koji.conf
@@ -1,7 +1,11 @@
 [composer]
 server = https://composer/
-ssl_cert = /share/client-crt.pem, /share/client-key.pem
 ssl_verify = /share/client-ca.pem
+
+[composer:oauth]
+client_id = "koji"
+client_secret = "koji"
+token_url = https://composer:8081/token
 
 [koji]
 server = https://localhost:4343/kojihub/

--- a/test/data/osbuild-composer.toml
+++ b/test/data/osbuild-composer.toml
@@ -1,6 +1,11 @@
 [koji]
-allowed_domains = ["client.osbuild.local", "localhost", "::1"]
 ca = "/etc/osbuild-composer/ca-crt.pem"
+enable_tls = true
+enable_mtls = false
+enable_jwt = true
+jwt_keys_url = "https://localhost:8081/certs"
+jwt_ca_file = "/etc/osbuild-composer/ca-crt.pem"
+jwt_acl_file = ""
 
 [koji.servers.localhost.kerberos]
 principal = "osbuild-krb@LOCAL"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -29,6 +29,9 @@ sudo /usr/libexec/koji-osbuild-tests/make-certs.sh /usr/share/koji-osbuild-tests
 greenprint "Starting osbuild-composer's socket"
 sudo systemctl enable --now osbuild-composer-api.socket
 
+greenprint "Starting mock OpenID server"
+sudo /usr/libexec/koji-osbuild-tests/run-openid.sh start
+
 greenprint "Building containers"
 sudo /usr/libexec/koji-osbuild-tests/build-container.sh /usr/share/koji-osbuild-tests
 
@@ -58,6 +61,9 @@ sudo /usr/libexec/koji-osbuild-tests/run-builder.sh stop /usr/share/koji-osbuild
 
 greenprint "Stopping containers"
 sudo /usr/libexec/koji-osbuild-tests/run-koji-container.sh stop
+
+greenprint "Stopping mock OpenID server"
+sudo /usr/libexec/koji-osbuild-tests/run-openid.sh stop
 
 greenprint "Removing generated CA cert"
 sudo rm /etc/pki/ca-trust/source/anchors/osbuild-ca-crt.pem

--- a/test/run-openid.sh
+++ b/test/run-openid.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -eu
+
+SERVER_PORT="8081"
+PIDFILE="/run/composer-openid-server.pid"
+
+server_start() {
+  echo "Starting mock OpenID server at :${SERVER_PORT}"
+
+  /usr/libexec/osbuild-composer-test/osbuild-mock-openid-provider \
+  -rsaPubPem /etc/osbuild-composer/client-crt.pem \
+  -rsaPem /etc/osbuild-composer/client-key.pem \
+  -cert /etc/osbuild-composer/composer-crt.pem \
+  -key /etc/osbuild-composer/composer-key.pem \
+  -a ":${SERVER_PORT}" \
+  -expires 10 &
+
+  until curl --output /dev/null --silent --fail "https://localhost:${SERVER_PORT}/token"; do
+    sleep 0.5
+  done
+
+  PID="$!"
+  echo "${PID}" > "${PIDFILE}"
+  echo "OpenID server running (${PID})"
+}
+
+server_stop() {
+  echo "Stopping mock OpenID server"
+
+  PID=$(cat "${PIDFILE}" 2> /dev/null || true)
+
+  if [ -z "$PID" ]; then
+     echo "Server not running!"
+     return
+  fi
+
+  echo "${PID}"
+
+  EXIT_CODE=0
+  kill "${PID}" > /dev/null || EXIT_CODE=$?
+
+  if [ "${EXIT_CODE}" != 0 ]; then
+    "Could not kill process ${PID}"
+  fi
+}
+
+if [  $# -lt 1 ]; then
+  echo -e "Usage: $0 <start|stop>"
+elif [ $1 == "start" ]; then
+  server_start
+elif [ $1 == "stop" ]; then
+  server_stop
+fi
+


### PR DESCRIPTION
Implement support for authentication via OAuth2 using the client credentials "Client Credentials Grant" flow (4.4 of RFC [6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)). For this a new configuration section is added to the config file, where the client_id, client_secret and token_url have to be specified.

The implementation does currently not support "refresh tokens", but does support refreshing the token if an `expires_in` is present in the token itself.

Corresponding unit tests have been added.