### PR TITLE
Fix command line argument names

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,7 @@ RUN dnf install -y \
     koji-utils \
     lsof \
     make \
+    openssl \
     podman \
     postgresql \
     pylint \

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,0 @@
-[MASTER]
-disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,attribute-defined-outside-init,too-many-arguments
-max-line-length=120

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -547,9 +547,9 @@ def main():
 
     subpar = sp.add_parser("compose", help='create a new compose')
     subpar.add_argument("name", metavar="NAME", help='The name')
-    subpar.add_argument("version", metavar="NAME", help='The version')
+    subpar.add_argument("version", metavar="VERSION", help='The version')
     subpar.add_argument("release", metavar="RELEASE", help='The release')
-    subpar.add_argument("distro", metavar="NAME", help='The distribution')
+    subpar.add_argument("distro", metavar="DISTRO", help='The distribution')
     subpar.add_argument("repo", metavar="REPO", help='The repository to use',
                         type=str, action="append", default=[])
     subpar.add_argument("arch", metavar="ARCHITECTURE", help='Request the architecture',

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -46,6 +46,7 @@ API_BASE = "api/composer-koji/v1/"
 # koji API. It is based on the corresponding OpenAPI specification
 # version '1' and should model it closely.
 
+
 class Repository:
     def __init__(self, baseurl: str, gpgkey: str = None):
         self.baseurl = baseurl

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[pylint.MASTER]
+disable=missing-docstring,too-few-public-methods,invalid-name,duplicate-code,superfluous-parens,too-many-locals,attribute-defined-outside-init,too-many-arguments,consider-using-with,consider-using-from-import
+
+[pylint.DESIGN]
+max-attributes=10
+max-statements=75
+
+[pycodestyle]
+max-line-length = 120


### PR DESCRIPTION
Also include `openssl` in the dev container and move the pylint configuration to `setup.cfg`.