### PR TITLE
ci: integration tests now adapt to the host

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,8 +26,6 @@ RPM:
   parallel:
     matrix:
       - RUNNER:
-          - aws/fedora-33-x86_64
-          - aws/fedora-33-aarch64
           - aws/fedora-34-x86_64
           - aws/fedora-34-aarch64
           - aws/rhel-8.4-ga-x86_64
@@ -45,7 +43,6 @@ Testing:
   parallel:
     matrix:
       - RUNNER:
-          - aws/fedora-33-x86_64
           # https://quay.io/repository/osbuild/postgres available only for x86_64
           # - aws/fedora-33-aarch64
           - aws/fedora-34-x86_64


### PR DESCRIPTION
Change the integration test so that it adapts to the host, i.e. it will take the name, version and architecture for the tags and urls for the repos from the host it is running on. This should make it more future proof since we now have a central place where this is configured: the ci configuration, i.e. `.gitlab-ci.yml`.