### PR TITLE
plugins: support for ostree specific options

### DIFF
--- a/plugins/cli/osbuild.py
+++ b/plugins/cli/osbuild.py
@@ -21,6 +21,12 @@ def parse_args(argv):
 
     parser.add_option("--nowait", action="store_false", dest="wait",
                       help="Don't wait on image creation")
+    parser.add_option("--ostree-parent", type=str, dest="ostree_parent",
+                      help="The OSTree commit parent for OSTree commit image types")
+    parser.add_option("--ostree-ref", type=str, dest="ostree_ref",
+                      help="The OSTree commit ref for OSTree commit image types")
+    parser.add_option("--ostree-url", type=str, dest="ostree_url",
+                      help="URL to the OSTree repo for OSTree commit image types")
     parser.add_option("--release", help="Forcibly set the release field")
     parser.add_option("--repo", action="append",
                       help=("Specify a repo that will override the repo used to install "
@@ -81,6 +87,21 @@ def handle_osbuild_image(options, session, argv):
 
     if args.skip_tag:
         opts["skip_tag"] = True
+
+    # ostree command line parameters
+    ostree = {}
+
+    if args.ostree_parent:
+        ostree["parent"] = args.ostree_parent
+
+    if args.ostree_ref:
+        ostree["ref"] = args.ostree_ref
+
+    if args.ostree_url:
+        ostree["url"] = args.ostree_url
+
+    if ostree:
+        opts["ostree"] = ostree
 
     # Do some early checks to be able to give quick feedback
     check_target(session, target)

--- a/plugins/hub/osbuild.py
+++ b/plugins/hub/osbuild.py
@@ -49,11 +49,31 @@ OSBUILD_IMAGE_SCHEMA = {
             "$ref": "#/definitions/options"
         }],
     "definitions": {
-        "options":{
+        "ostree": {
+            "title": "OSTree specific options",
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "parent": {
+                    "type": "string"
+                },
+                "ref": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "options": {
             "title": "Optional arguments",
             "type": "object",
             "additionalProperties": False,
             "properties": {
+                "ostree": {
+                    "type": "object",
+                    "$ref": "#/definitions/ostree"
+                },
                 "repo": {
                     "type": "array",
                     "description": "Repositories",

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -125,6 +125,63 @@ class TestCliPlugin(PluginTest):
         r = self.plugin.handle_osbuild_image(options, session, argv)
         self.assertEqual(r, 0)
 
+    def test_ostree_options(self):
+        # Check we properly handle ostree specific options
+
+        argv = [
+            # the required positional arguments
+            "name", "version", "distro", "target", "arch1",
+            # optional keyword arguments
+            "--repo", "https://first.repo",
+            "--repo", "https://second.repo",
+            "--release", "20200202.n2",
+            "--ostree-parent", "ostree/$arch/staging",
+            "--ostree-ref", "ostree/$arch/production",
+            "--ostree-url", "https://osbuild.org/repo",
+        ]
+
+        expected_args = ["name", "version", "distro",
+                         ['guest-image'],  # the default image type
+                         "target",
+                         ['arch1']]
+
+        expected_opts = {
+            "release": "20200202.n2",
+            "repo": ["https://first.repo", "https://second.repo"],
+            "ostree": {
+                "parent": "ostree/$arch/staging",
+                "ref": "ostree/$arch/production",
+                "url":  "https://osbuild.org/repo",
+            }
+        }
+
+        task_result = {"compose_id": "42", "build_id": 23}
+        task_id = 1
+        koji_lib = self.mock_koji_lib()
+
+        options = self.mock_options()
+        session = flexmock()
+
+        self.mock_session_add_valid_tag(session)
+
+        session.should_receive("osbuildImage") \
+               .with_args(*expected_args, opts=expected_opts) \
+               .and_return(task_id) \
+               .once()
+
+        session.should_receive("logout") \
+               .with_args() \
+               .once()
+
+        session.should_receive("getTaskResult") \
+               .with_args(task_id) \
+               .and_return(task_result) \
+               .once()
+
+        setattr(self.plugin, "kl", koji_lib)
+        r = self.plugin.handle_osbuild_image(options, session, argv)
+        self.assertEqual(r, 0)
+
     def test_target_check(self):
         # unknown build target
         session = flexmock()


### PR DESCRIPTION
OStree compose requests need special options, like the `ref` the
`parent` and the `url`. Add support for those options to all three
plugins:
  - The command line plugin now takes `--ostree-{parent,ref,url}` and passes it to koji via the existing options dictionary.
  - The JSON schemata in the hub plugin was adjusted to allow these new options.
  - Finally the builder plugin will look for the new `ostree` dict inside the options, create an `OSTreeOptions` object from it, and attach it to each image request.

NB: since the ostree options are per image request and are thus architecture dependent we support a "$arch" substition in the `parent` and `ref` options that will be resolved by the plugin; this allows to builds arch specific commits for with a single compose request.

Add the respective unit tests.