### PR TITLE
Add upstream release bot and enable packit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: "Create GitHub release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upstream release
+        uses: osbuild/release-action@main
+        with:
+          token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
+          slack_webhook_url: "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,25 @@
+# https://packit.dev/docs/configuration/
+
+specfile_path: koji-osbuild.spec
+
+synced_files:
+    - koji-osbuild.spec
+    - .packit.yaml
+
+upstream_package_name: koji-osbuild
+downstream_package_name: koji-osbuild
+
+copy_upstream_release_description: true
+
+upstream_tag_template: v{version}
+
+actions:
+  get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
+
+create_pr: true
+jobs:
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist_git_branches:
+      - fedora-all


### PR DESCRIPTION
I have already enabled packit-as-a-service in the osbuild organisation settings.

This is currently blocked by: https://github.com/osbuild/release-action/pull/4