### PR TITLE
Pre-release version bump

### DIFF
--- a/koji-osbuild.spec
+++ b/koji-osbuild.spec
@@ -1,7 +1,7 @@
 %global         forgeurl https://github.com/osbuild/koji-osbuild
 
 Name:           koji-osbuild
-Version:        3
+Version:        4
 Release:        0%{?dist}
 Summary:        Koji integration for osbuild composer
 


### PR DESCRIPTION
This is necessary once so we can enable the upstream release bot workflow,
which consists of just pushing a tag and bumping the version number
directly after the release is done.