### PR TITLE
builder: use correct secret when fetching token

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -298,7 +298,7 @@ class OAuth2(requests.auth.AuthBase):
         data = {
             "grant_type": "client_credentials",
             "client_id": self.id,
-            "client_secret": self.id
+            "client_secret": self.secret
         }
 
         res = http.post(self.token_url, data=data)

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -213,7 +213,7 @@ class MockComposer:  # pylint: disable=too-many-instance-attributes
             return [400, response_headers, "Invalid credentials"]
 
         client_secret = data.get("client_secret", [])
-        if len(client_secret) != 1 or client_secret[0] != "koji-osbuild":
+        if len(client_secret) != 1 or client_secret[0] != "s3cr3t":
             return [400, response_headers, "Invalid credentials"]
 
         token = {


### PR DESCRIPTION
Use the `self.secret` and not `self.id` for the secret. Doh. Mea culpa. Fix the corresponding test as well, which also checked for the wrong thing.
