### PR TITLE
test/builder: drop misleading quotes from config

### DIFF
--- a/test/container/builder/osbuild-koji.conf
+++ b/test/container/builder/osbuild-koji.conf
@@ -3,8 +3,8 @@ server = https://composer/
 ssl_verify = /share/client-ca.pem
 
 [composer:oauth]
-client_id = "koji"
-client_secret = "koji"
+client_id = koji
+client_secret = koji
 token_url = https://composer:8081/token
 
 [koji]


### PR DESCRIPTION
configparser treats quotes literally:

client_id = "koji"

translates to the following python string:

'"koji"'

This doesn't matter in the test because the oauth mock from osbuild-composer
actually ignores the credentials and return the token in every case.

But if you want to take this config as an example, you will probably put the
credentials automatically inside the quotes which will not work because a real
oauth server will refuse the client ID surrounded by quotes.

Note that .conf works different than .toml:

TOML requires to have strings in quotes. Yeah, consistency. 🤷