### PR TITLE
builder: rename gpg_key field to gpgkey for repos

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -103,7 +103,7 @@ class Repository:
             "rhsm": self.rhsm
         }
         if self.gpgkey:
-            res["gpg_key"] = self.gpgkey
+            res["gpgkey"] = self.gpgkey
             res["check_gpg"] = True
         if self.package_sets:
             res["package_sets"] = self.package_sets


### PR DESCRIPTION
We decided to do this late change to Cloud API in order to keep the field name
same for all the APIs:

https://github.com/osbuild/osbuild-composer/pull/2479

I strongly believe that gpgkeys are not used in any of the current koji-osbuild
deployments yet so this change should be safe.