### PR TITLE
builder: add support for proxying requests to composer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ ssl_cert = /share/worker-crt.pem, /share/worker-key.pem
 # directory containing certificates of trusted CAs.
 ssl_verify = /share/worker-ca.pem
 
+# URI of proxy that's used for all composer requests including requests to
+# an OAuth server if OAuth is enabled. Note that this proxy isn't used
+# to route any requests for Koji hub.
+proxy = http://squid.example.com:3128
+
 [composer:oauth]
 # Authorization via OAuth2/SSO, as alternative to client side certs.
 # The "Client Credentials Grant" (RFC 6749 section 4.4) flow is used,

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -469,6 +469,16 @@ class OSBuildImage(BaseTaskHandler):
             self.client.http.verify = val
             self.logger.debug("ssl verify: %s", val)
 
+        proxy = composer.get("proxy")
+        if proxy:
+            # route both http and https requests through the proxy
+            proxies = {
+                "http": proxy,
+                "https": proxy
+            }
+            self.client.http.proxies.update(proxies)
+            self.logger.debug("proxy: %s", proxy)
+
         if "composer:oauth" in cfg:
             oa = cfg["composer:oauth"]
             client_id, client_secret = oa["client_id"], oa["client_secret"]

--- a/test/unit/test_builder.py
+++ b/test/unit/test_builder.py
@@ -59,7 +59,7 @@ class MockComposer:  # pylint: disable=too-many-instance-attributes
         self.oauth = None
         self.oauth_check_delay = 0
 
-    def httpretty_regsiter(self):
+    def httpretty_register(self):
         httpretty.register_uri(
             httpretty.POST,
             urllib.parse.urljoin(self.url, "compose"),
@@ -579,7 +579,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=["s390x"])
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         with self.assertRaises(koji.GenericError):
             handler.handler(*args)
@@ -602,7 +602,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=arches)
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         res = handler.handler(*args)
         assert res, "invalid compose result"
@@ -648,7 +648,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=["x86_64"])
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         composer.status = "failure"
 
@@ -670,7 +670,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url)
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         args = ["name", "version", "distro",
                 ["image_type"],
@@ -698,7 +698,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url)
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         args = ["name", "version", "distro",
                 ["image_type"],
@@ -726,7 +726,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url)
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         for it in ("qcow2", "ec2", "ec2-ha", "ec2-sap"):
             args = ["name", "version", "distro",
@@ -747,7 +747,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url)
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         args = ["name", "version", "distro",
                 ["image_type"],
@@ -769,7 +769,7 @@ class TestBuilderPlugin(PluginTest):
         # for the osbuild-composer API
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=["x86_64"])
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         certs = [
             "test/data/example-crt.pem",
@@ -811,7 +811,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=["x86_64"])
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         # initialize oauth
         composer.oauth_activate(token_url)
@@ -851,7 +851,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=["x86_64"])
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         # initialize oauth
         composer.oauth_activate(token_url)
@@ -893,7 +893,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=["x86_64"])
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         # initialize oauth
         composer.oauth_activate(token_url)
@@ -933,7 +933,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=arches)
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         res = handler.handler(*args)
         assert res, "invalid compose result"
@@ -985,7 +985,7 @@ class TestBuilderPlugin(PluginTest):
 
         url = self.plugin.DEFAULT_COMPOSER_URL
         composer = MockComposer(url, architectures=arches)
-        composer.httpretty_regsiter()
+        composer.httpretty_register()
 
         res = handler.handler(*args)
         assert res, "invalid compose result"


### PR DESCRIPTION
We need koji-osbuild-builder to be able to connect to composer via a proxy
because koji builders in our internal deployment cannot reach
api.openshift.com directly. This commit adds a new option `proxy` to the
builder plugin config that controls whether a proxy is used to route all
requests to composer.

~I'm not sure if the integration test that I designed will work, will see. :shrug: I'm open to suggestions.~