### PR TITLE
packit: Enable Koji build integration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,10 +16,14 @@ upstream_tag_template: v{version}
 actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
 
-create_pr: false
 jobs:
 - job: propose_downstream
   trigger: release
+  metadata:
+    dist_git_branches:
+      - fedora-all
+- job: koji_build
+  trigger: commit
   metadata:
     dist_git_branches:
       - fedora-all


### PR DESCRIPTION
Packit has recently added integration for running builds on Koji. This job is triggered each time a spec-file change is detected in a new commit in dist-git.
For the time being, this change can be merged and can co-exist with our [fedora-bot](https://github.com/osbuild/fedora-bot) implementation.
Once the same change is merged into the koji-osbuild and osbuild repos as well we can drop it from fedora-bot and update our documentation.

Also drop the `create_pr` option, which was removed by Packit.

The related PRs in composer and osbuild are here:

- https://github.com/osbuild/osbuild-composer/pull/2626
- https://github.com/osbuild/osbuild/pull/1021