### PR TITLE
Support specifying upload options for image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
     - name: Install test dependencies
-      run: dnf -y install python3-flexmock python3-httpretty python3-jsonschema python3-koji python3-pylint python3-requests
+      run: dnf -y install python3-boto3 python3-flexmock python3-httpretty python3-jsonschema python3-koji python3-pylint python3-requests
 
     - name: Check out code
       uses: actions/checkout@v3

--- a/koji-osbuild.spec
+++ b/koji-osbuild.spec
@@ -143,10 +143,11 @@ Requires:       jq
 Requires:       koji
 Requires:       krb5-workstation
 Requires:       openssl
-Requires:       osbuild-composer >= 22
+Requires:       osbuild-composer >= 58
 Requires:       osbuild-composer-tests
 Requires:       podman
 Requires:       podman-plugins
+Requires:       python3-boto3
 
 %description tests
 Integration tests for koji-osbuild. To be run on a dedicated system.

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -116,6 +116,7 @@ class ImageRequest:
         self.image_type = image_type
         self.repositories = repos
         self.ostree: Optional[OSTreeOptions] = None
+        self.upload_options: Optional[Dict] = None
 
     def as_dict(self):
         arch = self.architecture
@@ -128,6 +129,8 @@ class ImageRequest:
         }
         if self.ostree:
             res["ostree"] = self.ostree.as_dict(self.architecture)
+        if self.upload_options:
+            res["upload_options"] = self.upload_options
 
         return res
 
@@ -687,6 +690,12 @@ class OSBuildImage(BaseTaskHandler):
 
         for ireq in ireqs:
             ireq.ostree = ostree
+
+        # Cloud upload options
+        upload_options = opts.get("upload_options")
+        if upload_options:
+            for ireq in ireqs:
+                ireq.upload_options = upload_options
 
         self.logger.debug("Creating compose: %s (%s)\n  koji: %s\n  images: %s",
                           nvr, distro, self.koji_url,

--- a/plugins/cli/osbuild.py
+++ b/plugins/cli/osbuild.py
@@ -49,6 +49,8 @@ def parse_args(argv):
 
     parser.add_option("--customizations", type=str, default=None, dest="customizations",
                       help="Additional customizations to pass to Composer (json file)")
+    parser.add_option("--upload-options", type=str, default=None, dest="upload_options",
+                      help="Cloud target upload options (json file)")
     parser.add_option("--nowait", action="store_false", dest="wait",
                       help="Don't wait on image creation")
     parser.add_option("--ostree-parent", type=str, dest="ostree_parent",
@@ -139,6 +141,11 @@ def handle_osbuild_image(options, session, argv):
     if args.customizations:
         with open(args.customizations, "r", encoding="utf-8") as f:
             opts["customizations"] = json.load(f)
+
+    # cloud upload options handling
+    if args.upload_options:
+        with open(args.upload_options, "r", encoding="utf-8") as f:
+            opts["upload_options"] = json.load(f)
 
     # Do some early checks to be able to give quick feedback
     check_target(session, target)

--- a/plugins/hub/osbuild.py
+++ b/plugins/hub/osbuild.py
@@ -94,6 +94,15 @@ OSBUILD_IMAGE_SCHEMA = {
                     "type": "object",
                     "$ref": "#/definitions/ostree"
                 },
+                "upload_options": {
+                    "oneOf": [
+                        {"$ref": "#/definitions/AWSEC2UploadOptions"},
+                        {"$ref": "#/definitions/AWSS3UploadOptions"},
+                        {"$ref": "#/definitions/GCPUploadOptions"},
+                        {"$ref": "#/definitions/AzureUploadOptions"},
+                        {"$ref": "#/definitions/ContainerUploadOptions"}
+                    ],
+                },
                 "repo": {
                     "type": "array",
                     "description": "Repositories",
@@ -111,6 +120,91 @@ OSBUILD_IMAGE_SCHEMA = {
                 "skip_tag": {
                     "type": "boolean",
                     "description": "Omit tagging the result"
+                }
+            }
+        },
+        "AWSEC2UploadOptions": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["region", "share_with_accounts"],
+            "properties": {
+                "region": {
+                    "type": "string",
+                },
+                "snapshot_name": {
+                    "type": "string",
+                },
+                "share_with_accounts": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "AWSS3UploadOptions": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["region"],
+            "properties": {
+                "region": {
+                    "type": "string"
+                }
+            }
+        },
+        "AzureUploadOptions": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["tenant_id", "subscription_id", "resource_group", "location"],
+            "properties": {
+                "tenant_id": {
+                    "type": "string"
+                },
+                "subscription_id": {
+                    "type": "string"
+                },
+                "resource_group": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "image_name": {
+                    "type": "string",
+                }
+            }
+        },
+        "GCPUploadOptions": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["region", "bucket"],
+            "properties": {
+                "region": {
+                    "type": "string"
+                },
+                "bucket": {
+                    "type": "string"
+                },
+                "image_name": {
+                    "type": "string",
+                },
+                "share_with_accounts": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "ContainerUploadOptions": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
                 }
             }
         }

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -39,7 +39,7 @@ greenprint "Testing Koji hub API access"
 koji --server=http://localhost:8080/kojihub --user=osbuild --password=osbuildpass --authtype=password hello
 
 greenprint "Copying credentials, certificates and configuration files"
-sudo /usr/libexec/koji-osbuild-tests/copy-creds.sh /usr/share/koji-osbuild-tests
+sudo -E /usr/libexec/koji-osbuild-tests/copy-creds.sh /usr/share/koji-osbuild-tests
 
 greenprint "Starting mock OpenID server"
 sudo /usr/libexec/koji-osbuild-tests/run-openid.sh start
@@ -63,6 +63,9 @@ greenprint "Creating Koji tag infrastructure"
 /usr/libexec/koji-osbuild-tests/make-tags.sh
 
 greenprint "Running integration tests"
+# export environment variables for the Boto3 client to work out of the box
+AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID:-}" \
+AWS_SECRET_ACCESS_KEY="${V2_AWS_SECRET_ACCESS_KEY:-}" \
 python3 -m unittest discover -v /usr/libexec/koji-osbuild-tests/integration/
 
 greenprint "Stopping koji builder"

--- a/test/integration/test_koji.py
+++ b/test/integration/test_koji.py
@@ -4,19 +4,38 @@
 
 
 import functools
+import json
+import logging
+import os
 import platform
-import unittest
+import re
+import shutil
 import string
 import subprocess
+import tempfile
+import unittest
+
+import boto3
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError as BotoClientError
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format = '%(asctime)s %(levelname)s: %(message)s', level = logging.INFO)
 
 
 def koji_command(*args, _input=None, _globals=None, **kwargs):
+    return koji_command_cwd(*args, _input=_input, _globals=_globals, **kwargs)
+
+
+def koji_command_cwd(*args, cwd=None, _input=None, _globals=None, **kwargs):
     args = list(args) + [f'--{k}={v}' for k, v in kwargs.items()]
     if _globals:
         args = [f'--{k}={v}' for k, v in _globals.items()] + args
     cmd = ["koji"] + args
-    print(cmd)
+    logger.info("Running %s", str(cmd))
     return subprocess.run(cmd,
+                          cwd=cwd,
                           encoding="utf-8",
                           stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT,
@@ -92,16 +111,28 @@ class SutInfo:
 
 
 class TestIntegration(unittest.TestCase):
+    logger = logging.getLogger(__name__)
 
     def setUp(self):
-        global_args = dict(
+        self.koji_global_args = dict(
             server="http://localhost:8080/kojihub",
+            topurl="http://localhost:8080/kojifiles",
             user="kojiadmin",
             password="kojipass",
             authtype="password")
         self.koji = functools.partial(koji_command,
                                       "osbuild-image",
-                                      _globals=global_args)
+                                      _globals=self.koji_global_args)
+
+        self.workdir = tempfile.mkdtemp()
+        # EC2 image ID to clean up in tearDown() if set to a value
+        self.ec2_image_id = None
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+        if self.ec2_image_id is not None:
+            self.delete_ec2_image(self.ec2_image_id)
+            self.ec2_image_id = None
 
     def check_res(self, res: subprocess.CompletedProcess):
         if res.returncode != 0:
@@ -116,6 +147,55 @@ class TestIntegration(unittest.TestCase):
                    "\n args: [" + " ".join(res.args) + "]" +
                    "\n error: " + res.stdout)
             self.fail(msg)
+
+    def task_id_from_res(self, res: subprocess.CompletedProcess) -> str:
+        """
+        Extract the Task ID from `koji osbuild-image` command output and return it.
+        """
+        r = re.compile(r'^Created task:[ \t]+(\d+)$', re.MULTILINE)
+        m = r.search(res.stdout)
+        if not m:
+            self.fail("Could not find task id in output")
+        return m.group(1)
+
+    @staticmethod
+    def get_ec2_client():
+        aws_region = os.getenv("AWS_REGION")
+        return boto3.client('ec2', config=BotoConfig(region_name=aws_region))
+
+    def check_ec2_image_exists(self, image_id: str) -> None:
+        """
+        Check if an EC2 image with the given ID exists.
+        If not, fail the test case.
+        """
+        client = self.get_ec2_client()
+        try:
+            resp = client.describe_images(ImageIds=[image_id])
+        except BotoClientError as e:
+            self.fail(str(e))
+        self.assertEqual(len(resp["Images"]), 1)
+
+    def delete_ec2_image(self, image_id: str) -> None:
+        client = self.get_ec2_client()
+        # first get the snapshot ID associated with the image
+        try:
+            resp = client.describe_images(ImageIds=[image_id])
+        except BotoClientError as e:
+            self.fail(str(e))
+        self.assertEqual(len(resp["Images"]), 1)
+
+        snapshot_id = resp["Images"][0]["BlockDeviceMappings"][0]["Ebs"]["SnapshotId"]
+        # deregister the image
+        try:
+            resp = client.deregister_image(ImageId=image_id)
+        except BotoClientError as e:
+            self.logger.warning("Failed to deregister image %s: %s", image_id, str(e))
+
+        # delete the associated snapshot
+        try:
+            resp = client.delete_snapshot(SnapshotId=snapshot_id)
+        except BotoClientError as e:
+            self.logger.warning("Failed to delete snapshot %s: %s", snapshot_id, str(e))
 
     def test_compose(self):
         """Successful compose"""
@@ -155,3 +235,67 @@ class TestIntegration(unittest.TestCase):
                         "UNKNOWNTAG",
                         sut_info.os_arch)
         self.check_fail(res)
+
+    def test_cloud_upload_aws(self):
+        """Successful compose with cloud upload to AWS"""
+        sut_info = SutInfo()
+
+        repos = []
+        for repo in sut_info.testing_repos():
+            url = repo["url"]
+            package_sets = repo.get("package_sets")
+            repos += ["--repo", url]
+            if package_sets:
+                repos += ["--repo-package-sets", package_sets]
+
+        package = "aws"
+        aws_region = os.getenv("AWS_REGION")
+
+        upload_options = {
+            "region": aws_region,
+            "share_with_accounts": [os.getenv("AWS_API_TEST_SHARE_ACCOUNT")]
+        }
+
+        upload_options_file = os.path.join(self.workdir, "upload_options.json")
+        with open(upload_options_file, "w", encoding="utf-8") as f:
+            json.dump(upload_options, f)
+
+        res = self.koji(package,
+                        sut_info.os_version_major,
+                        sut_info.composer_distro_name,
+                        sut_info.koji_tag,
+                        sut_info.os_arch,
+                        "--wait",
+                        *repos,
+                        f"--image-type={package}",
+                        f"--upload-options={upload_options_file}")
+        self.check_res(res)
+
+        task_id = self.task_id_from_res(res)
+        # Download files uploaded by osbuild plugins to the Koji build task.
+        # requires koji client of version >= 1.29.1
+        res_download = koji_command_cwd(
+            "download-task", "--all", task_id, cwd=self.workdir, _globals=self.koji_global_args
+        )
+        self.check_res(res_download)
+
+        # Extract information about the uploaded AMI from compose status response.
+        compose_status_file = os.path.join(self.workdir, "compose-status.noarch.json")
+        with open(compose_status_file, "r", encoding="utf-8") as f:
+            compose_status = json.load(f)
+
+        self.assertEqual(compose_status["status"], "success")
+        image_statuses = compose_status["image_statuses"]
+        self.assertEqual(len(image_statuses), 1)
+
+        upload_status = image_statuses[0]["upload_status"]
+        self.assertEqual(upload_status["status"], "success")
+        self.assertEqual(upload_status["type"], "aws")
+
+        upload_options = upload_status["options"]
+        self.assertEqual(upload_options["region"], aws_region)
+
+        image_id = upload_options["ami"]
+        self.assertNotEqual(len(image_id), 0)
+        self.ec2_image_id = image_id
+        self.check_ec2_image_exists(image_id)

--- a/test/make-tags.sh
+++ b/test/make-tags.sh
@@ -26,4 +26,6 @@ $KOJI add-pkg --owner kojiadmin "${TAG_CANDIDATE}" rhel-guest
 
 $KOJI add-pkg --owner kojiadmin "${TAG_CANDIDATE}" fedora-iot
 
+$KOJI add-pkg --owner kojiadmin "${TAG_CANDIDATE}" aws
+
 $KOJI regen-repo "${TAG_BUILD}"


### PR DESCRIPTION
### Notable changes

- Add support for specifying upload options on Koji CLI and thus upload the built image directly to the cloud as part of the build task. One can currently specify only one upload options, which will be used to upload all resulting images (image types x architectures matrix) to the cloud.
- Extend the integration test to test cloud upload with AWS image. The test case fetches relevant information from Koji to identify the image and then checks that it exists in AWS. The image is then deleted.
- Extend unit tests to cover the newly added functionality.