### PR TITLE
packit: Enable Bodhi updates workflow

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -27,3 +27,7 @@ jobs:
   metadata:
     dist_git_branches:
       - fedora-all
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-stable # rawhide updates are created automatically

--- a/test/container/builder/run-kojid.sh
+++ b/test/container/builder/run-kojid.sh
@@ -3,7 +3,7 @@ set -ux
 
 if ls /share/rpms/*.rpm 1> /dev/null 2>&1; then
    echo "Using RPMs"
-   rpm -i /share/rpms/koji-osbuild-?-1.*.rpm \
+   rpm -i /share/rpms/koji-osbuild-[[:digit:]]*-1.*.rpm \
           /share/rpms/koji-osbuild-builder-*.rpm
 else
   echo "Using local plugin"

--- a/test/container/hub/run-hub.sh
+++ b/test/container/hub/run-hub.sh
@@ -3,7 +3,7 @@ set -eux
 
 if ls /share/rpms/*.rpm 1> /dev/null 2>&1; then
    echo "Using RPMs"
-   rpm -i /share/rpms/koji-osbuild-?-1.*.rpm \
+   rpm -i /share/rpms/koji-osbuild-[[:digit:]]*-1.*.rpm \
           /share/rpms/koji-osbuild-hub-*.rpm
 else
   echo "Using local plugin"


### PR DESCRIPTION
This enables Bodhi updates created by packit (see https://packit.dev/docs/configuration/#bodhi_update).

It is preferable at this time to switch to packit because fedora-bot got blocked by authentication changes to Bodhi, so we need to manually publish all updates (until the auth method in Bodhi is fixed). See https://github.com/osbuild/fedora-bot/issues/41

We've been trialing this packit workflow in osbuild-composer for a while already successfully (https://github.com/osbuild/osbuild-composer/blob/main/.packit.yaml#L22).