### PR TITLE
Hub: support `image_type` being an array for backwards compatibility

### DIFF
--- a/test/unit/test_hub.py
+++ b/test/unit/test_hub.py
@@ -60,13 +60,41 @@ class TestHubPlugin(PluginTest):
 
         self.plugin.osbuildImage(*args, {})
 
+    def test_image_types_array(self):
+        context = self.mock_koji_context()
+
+        opts = {"repo": ["repo1", "repo2"],
+                "release": "1.2.3",
+                "skip_tag": True}
+        make_task_args = [
+            "name", "version", "distro",
+            "image_type",
+            "target",
+            ["arches"],
+            opts
+        ]
+        args = ["name", "version", "distro",
+                ["image_type"],
+                "target",
+                ["arches"],
+                opts]
+
+        task = {"channel": "image"}
+
+        kojihub = self.mock_kojihub(make_task_args, task)
+
+        setattr(self.plugin, "context", context)
+        setattr(self.plugin, "kojihub", kojihub)
+
+        self.plugin.osbuildImage(*args, {})
+
     def test_input_validation(self):
         context = self.mock_koji_context()
         setattr(self.plugin, "context", context)
 
         opts = {}
         args = ["name", "version", "distro",
-                ["image_type"],  # image type not an array
+                ["image_type", "image_type2"],  # only a single image type is allowed
                 "target",
                 ["arches"],
                 opts]


### PR DESCRIPTION
The support for specifying multiple `image_types` for a single compose
has been removed by [1]. This turned out to be problematic, because e.g.
Pungi uses the array type when triggering image builds via osbuild.

Bring back the support for specifying the `image_type` as an array, but
restrict it to a single item. This will cover the Pungi use-case, since
it is always passing a single `image_type` in the array. The array is
then converted to a string in the Hub plugin and passed as such to the
Builder plugin.

Extend unit tests covering the introduced compatibility layer.

[1] https://github.com/osbuild/koji-osbuild/commit/c7252650814f82281ee57b598cb2ad970b580451