### PR TITLE
Print more log messages to enable tracking of SLIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: "🐍 Lint"
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:latest
+      image: registry.fedoraproject.org/fedora:36
     steps:
 
     - name: Install test dependencies

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -717,7 +717,7 @@ class OSBuildImage(BaseTaskHandler):
         cid = client.compose_create(request)
         self.logger.info("Compose id: %s", cid)
 
-        self.logger.debug("Waiting for comose to finish")
+        self.logger.debug("Waiting for compose to finish")
         status = client.wait_for_compose(cid, callback=self.on_status_update)
 
         self.logger.debug("Compose finished: %s", str(status.as_dict()))

--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -20,6 +20,7 @@ import io
 import json
 import sys
 import time
+import logging
 import urllib.parse
 
 from string import Template
@@ -508,6 +509,7 @@ class OSBuildImage(BaseTaskHandler):
         self.composer_url = cfg["composer"]["server"]
         self.koji_url = cfg["koji"]["server"]
         self.client = Client(self.composer_url)
+        self.logger = logging.getLogger('koji.plugin.osbuild')
 
         self.logger.debug("composer: %s", self.composer_url)
         self.logger.debug("koji: %s", self.composer_url)
@@ -650,7 +652,7 @@ class OSBuildImage(BaseTaskHandler):
         self.logger.debug("Building image via osbuild %s, %s, %s, %s",
                           name, str(arches), str(target), str(opts))
 
-        self.logger.debug("Task id: %s", str(self.id))
+        self.logger.info("Task id: %s", str(self.id))
 
         target_info = self.session.getBuildTarget(target, strict=True)
         if not target_info:


### PR DESCRIPTION
In order to track service level indicators, we need to print more logs.

For the **Koji Hub plugin**, this means we print a message each time a request is received by the plugin. A second log message is printed once the task has been successfully created in Koji Hub's database. This also will allow us to measure the time it takes for Koji Hub to insert a task into its database.
Example messages:
```
[Tue Nov 15 19:43:05.996844 2022] [wsgi:error] [pid 17:tid 55] [remote 10.89.0.1:38666] 996 [INFO] m=None u=None p=17 r=?:? koji.plugins: Create osbuildImage task
[...]
[Tue Nov 15 19:43:06.003731 2022] [wsgi:error] [pid 17:tid 55] [remote 10.89.0.1:38666] 2022-11-15 19:43:06,003 [INFO] m=osbuildImage u=kojiadmin p=17 r=10.89.0.1:38666 koji.plugins: osbuildImage task 3 added to database
```


For the **Koji Builder plugin** we print a log message once a task has been received. We print a second log message once composer returns a compose id. This means the plugin completed one iteration successfully.

These logs are ingested into Splunk. In a dashboard we can then track the two subsequent requests and the duration between them.

As the newer version of pylint available in Fedora 37 that was just released fails with the current code base, I pinned the container so this can be addressed in a separate, subsequent PR.