### PR TITLE
hub: mark baseurl as required in repo schema

### DIFF
--- a/plugins/hub/osbuild.py
+++ b/plugins/hub/osbuild.py
@@ -69,6 +69,7 @@ OSBUILD_IMAGE_SCHEMA = {
             "title": "Repository options",
             "type": "object",
             "additionalProperties": False,
+            "required": ["baseurl"],
             "properties": {
                 "baseurl": {
                     "type": "string"

--- a/test/unit/test_hub.py
+++ b/test/unit/test_hub.py
@@ -111,6 +111,24 @@ class TestHubPlugin(PluginTest):
                     ["arches"]
                 ],
                 "opts": {}
+            },
+            # repo without `baseurl` is not allowed
+            {
+                "args": [
+                    "name",
+                    "version",
+                    "distro",
+                    "image_type",
+                    "target",
+                    ["arches"]
+                ],
+                "opts": {
+                    "repo": [
+                        {
+                            "package_sets": ["set1", "set2"]
+                        }
+                    ]
+                }
             }
         ]
 


### PR DESCRIPTION
Previously it the `repo` schema didn't mark the `baseurl` property as
required, although Cloud API requires it and the builder code made
assumptions about it being always provided.

Mark `baseurl` property as required in the `repo` schema and add unit
test for it.