### PR TITLE
koji-osbuild.spec: migrate the license field to SPDX

### DIFF
--- a/koji-osbuild.spec
+++ b/koji-osbuild.spec
@@ -11,7 +11,7 @@ Summary:        Koji integration for osbuild composer
 
 %forgemeta
 
-License:        ASL 2.0
+License:        Apache-2.0
 URL:            %{forgeurl}
 Source0:        %{forgesource}
 


### PR DESCRIPTION
See the relevant Fedora change:
https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1

We already verified that the SPDX format works well in the Enterprise Linux pipeline.