### PR TITLE
packit: enable epel and branched Fedoras

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,12 +22,18 @@ jobs:
   metadata:
     dist_git_branches:
       - fedora-all
+      - epel-8
+      - epel-9
 - job: koji_build
   trigger: commit
   metadata:
     dist_git_branches:
       - fedora-all
+      - epel-8
+      - epel-9
 - job: bodhi_update
   trigger: commit
   dist_git_branches:
     - fedora-stable # rawhide updates are created automatically
+    - epel-8
+    - epel-9

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,6 +34,6 @@ jobs:
 - job: bodhi_update
   trigger: commit
   dist_git_branches:
-    - fedora-stable # rawhide updates are created automatically
+    - fedora-branched # rawhide updates are created automatically
     - epel-8
     - epel-9


### PR DESCRIPTION
Two commits:

We got asked to ship this package also to EPEL. I already managed to create the branches and prepare the initial builds. The last step is to enable the downstream release automation. This commit thus enables EPELs for packit.

As we don't only want to get Bodhi updates for the stable releases, but also the ones still in development, we need to use 'fedora-branched'.

See https://packit.dev/docs/configuration/#aliases and
https://github.com/osbuild/osbuild-composer/commit/82d4fbbb4eacb6d4705982e2d82e7a33ee2b2021

FTR, EPEL 7 means Python 2, so let's not do this unless we really need to.