### PR TITLE
plugin/builder: increase retries

### DIFF
--- a/plugins/builder/osbuild.py
+++ b/plugins/builder/osbuild.py
@@ -374,8 +374,8 @@ class Client:
         self.url = urllib.parse.urljoin(url, API_BASE)
         self.http = requests.Session()
 
-        retries = Retry(total=5,
-                        backoff_factor=0.1,
+        retries = Retry(total=15,
+                        backoff_factor=0.3,
                         status_forcelist=[500, 502, 503, 504],
                         raise_on_status=False
                         )


### PR DESCRIPTION
The fedora koji instance often has trouble contacting the composer api, let's just make the retries a lot more generous.