### PR TITLE
GHA: enable the stale action to delete its saved state

### DIFF
--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -8,6 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
+      actions: write  # needed to clean up the saved action state
       issues: write
       pull-requests: write
     steps:


### PR DESCRIPTION
It turns out that the stale action is not able to delete its saved state due to missing permissions. As a result, it was not processing issues and PRs, that have been processed once, for almost a month.

The error in the job log was:
```
Warning: Error delete _state: [403] Resource not accessible by integration
```

The fix is to add `actions: write` to the action permissions