### PR TITLE
ghaction/release: Pass Slack bot token instead of webhook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
         uses: osbuild/release-action@main
         with:
           token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
-          slack_webhook_url: "${{ secrets.SLACK_WEBHOOK_URL }}"
+          slack_bot_token: "${{ secrets.SLACK_BOT_TOKEN }}"


### PR DESCRIPTION
We have updated our Slack integration to use a Slack bot token instead of a webhook to be able to post threaded responses or react to messages. For reference see: https://github.com/osbuild/release-action/pull/35